### PR TITLE
fix: unblock Jest test suite (.babelrc filetypes syntax)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,9 @@
     ["react-css-modules", {
       "generateScopedName": "[name]__[local]___[path]",
       "filetypes": {
-        ".styl": "sugarss"
+        ".styl": {
+          "syntax": "sugarss"
+        }
       }
     }]
   ],


### PR DESCRIPTION
## 概要
Jest テストスイート全 24 ファイルが**1 件もテストを実行できず** `Invalid configuration` で落ちていた問題を修正します。

## 原因
`.babelrc` の `babel-plugin-react-css-modules` 設定で、`filetypes['.styl']` を文字列 `"sugarss"` で指定していました。インストール済みの `babel-plugin-react-css-modules@3.4.2` のスキーマは、この値を **オブジェクト** (`{ "syntax": "sugarss" }`) として要求するため、スキーマ検証に失敗していました。

```diff
 "filetypes": {
-  ".styl": "sugarss"
+  ".styl": {
+    "syntax": "sugarss"
+  }
 }
```

## 効果
- 修正前: 24 スイートすべてが起動時にエラー → **0 テスト実行**
- 修正後: **83/92 テストが pass**（残り 9 スイートの失敗は `window.localStorage` undefined 等、本 PR とは無関係な環境/セットアップ起因の別課題。別途対応予定）

## テスト
- `npx jest tests/lib/slugify.test.js` → 7 passed
- `npm run lint` → clean（pre-commit フック通過）

## 影響範囲
ビルド設定のみ。アプリの実行時挙動には影響しません（`.styl` の css-modules パース構文を正しい形式に直しただけ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)