### PR TITLE
fix: enable localStorage in Jest via testURL (http://localhost/)

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,6 +207,7 @@
     "babel": "inherit"
   },
   "jest": {
+    "testURL": "http://localhost/",
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
       "\\.(css|less|styl)$": "identity-obj-proxy"


### PR DESCRIPTION
## 概要
localStorage を使う Jest スイートが **起動時に落ちていた** 問題を修正します。

## 原因
Jest 22 のデフォルト `testURL` は `about:blank`（opaque origin）。この origin 下では jsdom が
`SecurityError: localStorage is not available for opaque origins` を投げ、`localStorage` を触る全スイートが実行不能でした。

```diff
 "jest": {
+  "testURL": "http://localhost/",
   "moduleNameMapper": { ... }
 }
```

`testURL` を実 origin に設定すると `window.localStorage` が利用可能になります（このデフォルト化は Jest v23 以降）。

## 効果（サポート対象の Node 14 で計測）
- 修正前: 実行可能 92 テスト / 83 pass
- 修正後: 実行可能 **110 テスト / 101 pass**

## 残課題（本PRの対象外・別PR予定）
- `sugarss` 未インストールによる `.styl` import スイートの失敗
- dataApi 系の `Target storage doesn't exist`（テスト側の storage シード問題）

## テスト
- `volta run node jest`（Node 14.21.3）で計測。`npm run lint` clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)