### PR TITLE
fix: add missing sugarss devDependency for .styl css-modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,6 +187,7 @@
     "style-loader": "^0.12.4",
     "stylus": "^0.52.4",
     "stylus-loader": "^2.5.1",
+    "sugarss": "^1.0.1",
     "webpack": "^1.15.0",
     "webpack-dev-server": "^1.16.5"
   },


### PR DESCRIPTION
## 概要
`.styl` を import するモジュールを含む Jest スイートが `Cannot find module 'sugarss'` で実行不能だった問題を修正します。

## 原因
`.babelrc` の `babel-plugin-react-css-modules` 設定は `.styl` を `sugarss` 構文でパースする指定ですが、`sugarss` が **package.json に宣言されておらず node_modules からも prune 済み**でした（package-lock.json には参照が残っていた）。

```diff
 "stylus-loader": "^2.5.1",
+"sugarss": "^1.0.1",
 "webpack": "^1.15.0",
```

- `sugarss@^1.0.1` は本プロジェクトが解決する **postcss 6** 向けのリリース。
- npm 6 でインストールし、`package-lock.json` を lockfileVersion 1 のまま維持。

## 効果（Node 14.21.3）
- 修正前: 実行可能 110 / 101 pass・8 スイート失敗
- 修正後: 実行可能 **131 / 122 pass**・6 スイート失敗（`spellcheck` 等が PASS に）

## 残課題（別PR予定）
- `TagListItem.styl:98` の curly bracket を sugarss が拒否（`.styl` 構文側の修正）
- dataApi 系 `Target storage doesn't exist`（テストの storage シード）

🤖 Generated with [Claude Code](https://claude.com/claude-code)