### PR TITLE
fix: make test localStorage writable so dataApi suites inject storage

### DIFF
--- a/tests/jest.js
+++ b/tests/jest.js
@@ -10,3 +10,15 @@ global.Raphael = {
 global._ = {
   extend: jest.genMockFunction()
 }
+
+// jsdom (with a configured testURL) exposes window.localStorage as a
+// getter-only accessor. Test files that inject their own storage via
+// `window.localStorage = ...` would otherwise silently no-op, leaving
+// findStorage() reading an empty store. Redefine it as a writable,
+// configurable property so those per-test injections take effect.
+const DomStorage = require('dom-storage')
+Object.defineProperty(global, 'localStorage', {
+  value: new DomStorage(null, { strict: false }),
+  writable: true,
+  configurable: true
+})


### PR DESCRIPTION
## 概要
dataApi 系スイート（`createNote` / `createFolder` / `deleteFolder` / `createNoteFromUrl`）と `find-storage` が `Target storage doesn't exist.` で失敗していた問題を修正します。

## 原因
`testURL` 設定後、jsdom は `window.localStorage` を **getter 専用アクセサ**として公開します。dataApi テストは自前の `dom-storage` を `window.localStorage = global.localStorage = new Storage(...)` で注入しますが、**getter 専用プロパティへの代入は暗黙に no-op** になります。

結果として：
- seed したデータはテストのローカル変数（dom-storage インスタンス）に入る
- 一方 `findStorage()` は bare `localStorage`（= jsdom の空ストア）を読む
- → storages が見つからず例外

## 修正
共有セットアップ `tests/jest.js` で `localStorage` を **writable / configurable** な data プロパティとして再定義し、各テストの注入が効くようにします。

```js
const DomStorage = require('dom-storage') // 既存 devDependency
Object.defineProperty(global, 'localStorage', {
  value: new DomStorage(null, { strict: false }),
  writable: true,
  configurable: true
})
```

## 効果（Node 14.21.3）
- 修正前: 6 スイート失敗 / 122 pass
- 修正後: **1 スイート失敗のみ / 127 pass・テスト失敗 0**
- 既存 pass スイートへの regression なし

## 残課題（別PR予定）
- `TagListItem.snapshot`：`TagListItem.styl` の Stylus 補間 `{theme}` を sugarss が解析できない（最後の 1 スイート）

🤖 Generated with [Claude Code](https://claude.com/claude-code)