### PR TITLE
chore: replace deprecated react/jsx-space-before-closing ESLint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,14 @@
     "react/no-deprecated": "warn",
     "prettier/prettier": ["error"],
     "react/no-unknown-property": [ "error", { "ignore": ["styleName"] } ],
-    "camelcase": "off"
+    "camelcase": "off",
+    "react/jsx-space-before-closing": "off",
+    "react/jsx-tag-spacing": ["error", {
+      "beforeSelfClosing": "always",
+      "closingSlash": "allow",
+      "afterOpening": "allow",
+      "beforeClosing": "allow"
+    }]
   },
   "globals": {
     "FileReader": true,


### PR DESCRIPTION
## 概要
`npm run lint` および husky pre-commit フック実行のたびに表示されていた ESLint の deprecation 警告を解消します。

```
The react/jsx-space-before-closing rule is deprecated. Please use the
react/jsx-tag-spacing rule with the "beforeSelfClosing" option instead.
```

## 原因
`standard-jsx` config が `react/jsx-space-before-closing`（非推奨）を有効化しているため、毎回警告が出ていました。

## 修正
- 非推奨ルールを `off` に上書き
- 後継の `react/jsx-tag-spacing` を **`beforeSelfClosing: "always"` のみ**有効化（他は `allow`）→ 従来挙動と完全に等価

```diff
+"react/jsx-space-before-closing": "off",
+"react/jsx-tag-spacing": ["error", {
+  "beforeSelfClosing": "always",
+  "closingSlash": "allow",
+  "afterOpening": "allow",
+  "beforeClosing": "allow"
+}]
```

## 効果
- `npm run lint` → **警告なし・エラー 0・exit 0**
- 既存コードへの修正は不要（全ファイルが新ルールを満たす）

🤖 Generated with [Claude Code](https://claude.com/claude-code)