### PR TITLE
ci: add GitHub Actions workflow (lint + Jest on Node 14)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,11 @@ jobs:
           node-version: '14.21.3'
 
       - name: Install dependencies
-        run: npm ci
+        # package-lock.json is gitignored and yarn.lock is the tracked
+        # lockfile, so `npm ci` has no lockfile to read on a clean checkout.
+        # Use `npm install` (the historical Travis behaviour) to resolve
+        # from package.json directly.
+        run: npm install --no-audit --no-fund
 
       - name: Lint
         run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+# Runs lint and the Jest test suite on every push and pull request to main.
+# Pinned to Node 14.21.3 to match the Volta pin and Electron 4 compatibility.
+# No untrusted event input is referenced in any run: step.
+# The AVA data-layer suite is not run here yet (tracked separately); see the
+# modernization roadmap.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 14.21.3
+        uses: actions/setup-node@v4
+        with:
+          node-version: '14.21.3'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Jest
+        run: npx jest --ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ jobs:
         with:
           node-version: '14.21.3'
 
+      - name: Rewrite git:// to https://
+        # A transitive dependency (eve, via Raphael/snap.svg) is referenced
+        # over the unauthenticated git:// protocol, which GitHub disabled in
+        # 2022. Rewriting to https:// lets the install resolve it.
+        run: git config --global url."https://github.com/".insteadOf "git://github.com/"
+
       - name: Install dependencies
         # package-lock.json is gitignored and yarn.lock is the tracked
         # lockfile, so `npm ci` has no lockfile to read on a clean checkout.


### PR DESCRIPTION
## 概要
defunct な Travis CI に代わり、**GitHub Actions** で lint と Jest を自動実行する CI を追加します。スイートが完全グリーン（128 pass）になった今、回帰検知と今後のモダナイズ検証の土台になります。

## 内容
- トリガー: `main` への push / PR、`workflow_dispatch`
- Node **14.21.3**（Volta pin / Electron 4 互換に合わせる）
- `npm ci` → `npm run lint` → `npx jest --ci`
- `run:` ステップに信頼できないイベント入力は一切使用しない（インジェクション対策）

## 補足
- AVA データ層スイートは未接続。Jest で修正したのと同種の getter-only `localStorage` セットアップ不具合があり、別途対応予定（モダナイズ・ロードマップに記載予定）。
- この PR の CI 自体がこの PR 上で実行されるため、グリーンを確認してからマージします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)