### PR TITLE
fix: restore AVA suite (writable browser-env globals) + add AVA to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,9 @@
 name: CI
 
-# Runs lint and the Jest test suite on every push and pull request to main.
-# Pinned to Node 14.21.3 to match the Volta pin and Electron 4 compatibility.
-# No untrusted event input is referenced in any run: step.
-# The AVA data-layer suite is not run here yet (tracked separately); see the
-# modernization roadmap.
+# Runs lint, the AVA data-layer suite, and the Jest suite on every push and
+# pull request to main. Pinned to Node 14.21.3 to match the Volta pin and
+# Electron 4 compatibility. No untrusted event input is referenced in any
+# run: step.
 
 on:
   push:
@@ -40,6 +39,9 @@ jobs:
 
       - name: Lint
         run: npm run lint
+
+      - name: AVA (data layer)
+        run: npm run ava
 
       - name: Jest
         run: npx jest --ci

--- a/tests/helpers/setup-browser-env.js
+++ b/tests/helpers/setup-browser-env.js
@@ -1,6 +1,19 @@
 import browserEnv from 'browser-env'
 browserEnv(['window', 'document', 'navigator'])
 
+// browser-env installs window/document/navigator as getter-only globals.
+// Several data-layer test files set up their own jsdom by reassigning these
+// globals (e.g. `global.document = require('jsdom').jsdom(...)`), which would
+// throw against getter-only properties. Redefine them as writable so those
+// per-file overrides take effect.
+for (const key of ['window', 'document', 'navigator']) {
+  Object.defineProperty(global, key, {
+    configurable: true,
+    writable: true,
+    value: global[key]
+  })
+}
+
 // for CodeMirror mockup
 document.body.createTextRange = function() {
   return {
@@ -19,9 +32,18 @@ document.body.createTextRange = function() {
   }
 }
 
-window.localStorage = {
-  // polyfill
-  getItem() {
-    return '{}'
+// browser-env's jsdom exposes window.localStorage as a getter-only
+// accessor, so a plain assignment throws "Cannot set property localStorage
+// of #<Window> which has only a getter". Define it as a writable,
+// configurable property so the polyfill takes effect (and so individual
+// test files can still override it with their own storage).
+Object.defineProperty(window, 'localStorage', {
+  configurable: true,
+  writable: true,
+  value: {
+    // polyfill
+    getItem() {
+      return '{}'
+    }
   }
-}
+})


### PR DESCRIPTION
## 概要
AVA データ層スイートが**全件モジュールロードで即クラッシュ**していた問題を修正し、AVA を CI に組み込みます。

## 原因
`tests/helpers/setup-browser-env.js` の `browser-env` は `window` / `document` / `navigator`（および `window.localStorage`）を **getter 専用グローバル**として定義します。しかしヘルパや各テストファイルはこれらを再代入します（例: `window.localStorage = new Storage()`、`global.document = require('jsdom').jsdom(...)`）。getter 専用プロパティへの代入は `Cannot set property X of #<...> which has only a getter` で throw します。

## 修正
`window` / `document` / `navigator` と localStorage ポリフィルを **writable / configurable** な data プロパティとして再定義し、各テストの上書きが効くようにします。

## 効果（Node 14.21.3）
- AVA: **実行不能（0）→ 14 passing**
- CI ワークフローに **AVA ステップを追加** → 以後 `ava + jest` 全体が毎 PR で検証されます

## 検証
- ローカル（Node 14）で `npm run ava` → 14 passed / exit 0、`npm run lint` clean
- この PR の CI で `ava + jest` のグリーンを確認してからマージします

🤖 Generated with [Claude Code](https://claude.com/claude-code)