### PR TITLE
fix: call blur() on search clear + remove two no-op statements

### DIFF
--- a/browser/main/TopBar/index.js
+++ b/browser/main/TopBar/index.js
@@ -74,7 +74,7 @@ class TopBar extends React.Component {
       search: '',
       isSearching: false
     })
-    this.refs.search.childNodes[0].blur
+    this.refs.search.childNodes[0].blur()
     dispatch(push('/searched'))
     e.preventDefault()
     this.debouncedUpdateKeyword('')

--- a/browser/main/lib/dataApi/renameStorage.js
+++ b/browser/main/lib/dataApi/renameStorage.js
@@ -24,8 +24,6 @@ function renameStorage(key, name) {
   targetStorage.name = name
   localStorage.setItem('storages', JSON.stringify(cachedStorageList))
 
-  targetStorage.path
-
   return resolveStorageData(targetStorage)
 }
 

--- a/browser/main/lib/dataApi/updateNote.js
+++ b/browser/main/lib/dataApi/updateNote.js
@@ -128,10 +128,6 @@ function updateNote(storageKey, noteKey, input) {
       noteData.isPinned = false
     }
 
-    if (noteData.type === 'SNIPPET_NOTE') {
-      noteData.title
-    }
-
     Object.assign(noteData, input, {
       key: noteKey,
       updatedAt: new Date(),


### PR DESCRIPTION
## 概要
モダン linter（`no-unused-expressions`）で検出した「評価しても何も起きない式文」を調査し、**実バグ1件 + デッドコード2件**を修正します。

## 修正内容
### 🐛 実バグ: 検索クリア時に blur されない（TopBar）
`this.refs.search.childNodes[0].blur` が **`()` の無いプロパティ参照**で、クリアボタン押下時に検索入力が blur されていませんでした。`()` を補います。
- 同ファイル `handleOnSearchFocus` が**同一要素**に対し `el.blur()` を正しく呼んでおり（L140）、意図と blur メソッドの存在が確認できます。

### 🧹 デッドコード除去（挙動変更なし）
- `renameStorage.js`: `targetStorage.path` という裸の no-op 文を削除。
- `updateNote.js`: `if (noteData.type === 'SNIPPET_NOTE') { noteData.title }` の no-op ブロックを削除（プロパティ参照のみで何もしない。新規ノートは上部で `noteData.title = ''` 済み）。

## 検証
- `npm run lint` clean、**AVA 14 / Jest 128 passing**（`renameStorage`・`updateNote` は AVA データ層テストでカバー）
- TopBar の blur は UI 挙動のため自動テスト対象外ですが、同一パターンの既存正常呼び出しに基づく 1 文字修正で低リスクです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)