### PR TITLE
fix: restore production build (remove redundant react-css-modules babel plugin)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,29 +2,7 @@
   "presets": ["react", "es2015"],
   "env": {
     "development": {
-      "presets": ["react-hmre"],
-      "plugins": [
-        ["react-css-modules", {
-          "generateScopedName": "[name]__[local]___[path]",
-          "filetypes": {
-            ".styl": {
-              "syntax": "sugarss"
-            }
-          }
-        }]
-      ]
-    },
-    "production": {
-      "plugins": [
-        ["react-css-modules", {
-          "generateScopedName": "[name]__[local]___[path]",
-          "filetypes": {
-            ".styl": {
-              "syntax": "sugarss"
-            }
-          }
-        }]
-      ]
+      "presets": ["react-hmre"]
     },
     "test": {
       "presets": ["env" ,"react", "es2015"],


### PR DESCRIPTION
## 概要
**本番/開発ビルドが壊れていた**問題を修正します。これは「アプリがビルドできない」= 最重要級の不具合です。

## 原因
`babel-plugin-react-css-modules` が、import される全 `.styl` を **sugarss** でパースして `styleName` をコンパイル時解決しようとします。しかし本プロジェクトの Stylus は補間 `{theme}`・ミックスイン・`for` ループ等の **Stylus 専用構文**を含み、sugarss は解析不能。結果、webpack(babel-loader → react-css-modules)で `CssSyntaxError` が出てビルドが失敗していました（`requireCssModule` 内）。

## 着眼点：このプラグインは完全に冗長
`styleName` を使う **62 コンポーネント全てがランタイムの `CSSModules` HOC**（`browser/lib/CSSModules` → `react-css-modules`）でラップされており、`styleName → className` は**実行時に css-loader の `styles` から解決**されます。クラスのスコープ化は webpack 側（`css?modules&localIdentName=[name]__[local]___[path]!stylus`）が担うため、babel プラグインを外しても**生成 CSS・実行時 className は一切変わりません**。

## 修正
dev / production の babel env から `react-css-modules` を削除（test env からは既に削除済み）。`.babelrc` のみの変更。

## 検証（このマシンで実機確認）
- `webpack --config webpack-production.config.js` が**成功し `compiled/main.js`（13MB）を生成**（修正前は CssSyntaxError でハードエラー）
- フルスイート: **AVA 14 / Jest 128 passing**、lint clean

## 補足
`babel-plugin-react-css-modules` と `sugarss` は未使用になりました（依存削除は別PRで）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)