### PR TITLE
ci: verify the production build on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: CI
 
-# Runs lint, the AVA data-layer suite, and the Jest suite on every push and
-# pull request to main. Pinned to Node 14.21.3 to match the Volta pin and
-# Electron 4 compatibility. No untrusted event input is referenced in any
-# run: step.
+# Runs lint, the AVA data-layer suite, the Jest suite, and the production
+# webpack build on every push and pull request to main. Pinned to Node
+# 14.21.3 to match the Volta pin and Electron 4 compatibility. No untrusted
+# event input is referenced in any run: step.
 
 on:
   push:
@@ -41,3 +41,11 @@ jobs:
 
       - name: Jest
         run: npx jest --ci
+
+      - name: Build (webpack production)
+        # webpack 1 exits 0 even on compilation errors, so use --bail to fail
+        # on the first error and assert the bundle was actually emitted.
+        run: |
+          rm -rf compiled
+          node ./node_modules/.bin/webpack --config webpack-production.config.js --bail
+          test -f compiled/main.js


### PR DESCRIPTION
## 概要
**本番ビルドを CI で検証**するステップを追加します。直前の不具合（react-css-modules プラグインが Stylus を sugarss で解析できずビルド失敗）は、**CI でビルドを実行していなかったため誰も気付けませんでした**。再発防止です。

## 実装
```yaml
- name: Build (webpack production)
  run: |
    rm -rf compiled
    node ./node_modules/.bin/webpack --config webpack-production.config.js --bail
    test -f compiled/main.js
```
- **webpack 1 はコンパイルエラーでも exit 0** になるため、`--bail` で最初のエラーで失敗させる
- さらに `compiled/main.js` の生成を assert（古い成果物を消してから）
- lint/test では捕捉できないビルド回帰を防止

## 検証
ローカル（Node 14）で `--bail` ビルド成功・exit 0・`compiled/main.js`（13MB）生成を確認。この PR の CI がビルドステップ込みで通ることを確認してからマージします。
🤖 Generated with [Claude Code](https://claude.com/claude-code)