### PR TITLE
docs: record verified Babel 7 / Webpack / AVA coupling in roadmap

### DIFF
--- a/docs/MODERNIZATION.md
+++ b/docs/MODERNIZATION.md
@@ -79,25 +79,44 @@ large config migrations. Do each on its own branch, one at a time.
 Highest risk. Each needs `npm run dev` + `npm run compile` validated by hand on
 a supported machine, plus smoke-testing the packaged app. Sequence matters.
 
-1. [ ] **Babel 6 → 7** — prerequisite for most modern tooling. Touches every
-       transform; `.babelrc` → `babel.config.js`, preset renames
-       (`babel-preset-es2015` → `@babel/preset-env`), `react-css-modules`
-       plugin 3 → 5.
-2. [ ] **Webpack 1 → 5** — the loader syntax in `webpack*.config.js`
-       (`style!css?modules!stylus`) is Webpack 1 era and must be fully
-       rewritten to the `module.rules` / loader-array form.
-3. [ ] **React 16 → 18/19** — audit class-lifecycle usage
+> **Verified coupling (spike, 2026-06).** A Babel 6→7 spike on a throwaway
+> branch proved these majors are a **coupled big-bang, not incremental**:
+> - **Jest works on Babel 7** by adding `babel-core@7.0.0-bridge.0` alongside
+>   `@babel/core` (lets jest 22's `babel-jest` load Babel 7). 128/128 passed.
+> - **AVA 0.25 is hard-bound to babel-core 6** — it bundles its own
+>   `babel-core@6` and rejects `"babel": false`, so it cannot process Babel-7
+>   presets. Babel 7 therefore forces an **AVA 0.25 → 4+** upgrade.
+> - **`babel-loader@8` requires webpack ≥ 2**; under webpack 1 it silently
+>   produces a broken ~29 KB bundle (vs the real ~13 MB / 1602 modules), even
+>   though webpack 1 still exits 0. Babel 7 therefore forces the **Webpack
+>   1 → 2+** upgrade too.
+> - The test-time `browser/...` import resolution (`babel-plugin-webpack-alias`)
+>   has a Babel-7 replacement that works: `babel-plugin-webpack-alias-7`.
+>
+> Net: **Babel 7 + Webpack 2+ + babel-loader 8 + AVA 4** must land together.
+> Do them on one branch, gated by the CI build + suite, with manual app
+> smoke-testing before merge.
+
+1. [ ] **Babel 6 → 7 + Webpack 1 → 5 + AVA 0.25 → 4 (one coordinated branch)**
+       — preset renames (`babel-preset-es2015` → `@babel/preset-env`,
+       `@babel/preset-react`), `@babel/register` for AVA, `babel-loader@8`,
+       `babel-core@7.0.0-bridge.0` for jest, `babel-plugin-webpack-alias-7`,
+       and rewriting the webpack-1 loader syntax
+       (`style!css?modules!stylus`) to `module.rules`. The dev HMR preset
+       (`react-hmre` / `babel-plugin-react-transform`) → `react-hot-loader`.
+2. [ ] **React 16 → 18/19** — audit class-lifecycle usage
        (`react/no-deprecated` is currently a warning), `ReactDOM.render` →
-       `createRoot`, and the `react-hot-loader` / `react-hmre` dev setup.
-4. [ ] **Electron 4 → latest** — the largest change: arm64 support, context
+       `createRoot`, and the dev hot-reload setup.
+3. [ ] **Electron 4 → latest** — the largest change: arm64 support, context
        isolation, `remote` module removal, `nodeIntegration` review, native
        module rebuilds, and security-model changes. Also unblocks running the
        app on Apple Silicon, which in turn makes Tier 3 verifiable locally.
 
 ## Suggested order
 
-Foundation (done) → Tier 1 → Tier 2 → Babel 7 → Webpack 5 → React 18 →
-Electron latest. Electron is listed last because every other upgrade is easier
-to verify once the app builds, but bringing Electron forward is also what
-finally enables local arm64 verification — so it may be worth a spike early to
-unblock the rest.
+Foundation (done) → Tier 1 → Tier 2 → **(Babel 7 + Webpack 5 + AVA 4 as one
+coordinated step)** → React 18 → Electron latest. The Babel/Webpack/AVA step is
+a single big-bang because of the coupling documented above. Electron is listed
+last because every other upgrade is easier to verify once the app builds, but
+bringing Electron forward is also what finally enables local arm64
+verification — so it may be worth a spike early to unblock the rest.


### PR DESCRIPTION
## 概要
Babel 6→7 のスパイク（使い捨てブランチ・revert 済み）で得た**フレームワーク major の結合関係**を実測に基づきロードマップへ記録します。これにより大型移行が de-risk されます。

## 実測結果（重要）
フレームワーク major は **一括 big-bang** であり、段階移行はできません：
- **Jest は Babel 7 で動く** — `babel-core@7.0.0-bridge.0` を併用すれば jest 22 の babel-jest が Babel 7 を読める（128/128 pass）
- **AVA 0.25 は babel-core 6 に強結合** — 自前の `babel-core@6` を同梱し `"babel": false` を拒否 → Babel 7 は **AVA 0.25 → 4+** を強制
- **`babel-loader@8` は webpack ≥ 2 必須** — webpack 1 では**壊れた ~29KB バンドル**を無言で生成（正常は ~13MB / 1602 modules、webpack 1 は exit 0 のまま）→ Babel 7 は **Webpack 1 → 2+** を強制
- テスト時の `browser/...` 解決は **`babel-plugin-webpack-alias-7`** が Babel 7 対応の代替として機能

→ **Babel 7 + Webpack 2+ + babel-loader 8 + AVA 4 を 1 ブランチで同時投入**し、CI（build + suite）と手動スモークで検証する必要があります。

docs のみ（コード影響なし）。
🤖 Generated with [Claude Code](https://claude.com/claude-code)