### PR TITLE
docs: record React 16->18/19 readiness audit in roadmap

### DIFF
--- a/docs/MODERNIZATION.md
+++ b/docs/MODERNIZATION.md
@@ -104,9 +104,14 @@ a supported machine, plus smoke-testing the packaged app. Sequence matters.
        and rewriting the webpack-1 loader syntax
        (`style!css?modules!stylus`) to `module.rules`. The dev HMR preset
        (`react-hmre` / `babel-plugin-react-transform`) → `react-hot-loader`.
-2. [ ] **React 16 → 18/19** — audit class-lifecycle usage
-       (`react/no-deprecated` is currently a warning), `ReactDOM.render` →
-       `createRoot`, and the dev hot-reload setup.
+2. [ ] **React 16 → 18 (feasible) / → 19 (gated)** — audit (2026-06):
+       - Class lifecycles are already migrated to `UNSAFE_` prefixes (no bare
+         `componentWillMount`/`WillReceiveProps`/`WillUpdate`), so they keep
+         working through React 18.
+       - Only **2** `ReactDOM.render` call sites → `createRoot`.
+       - **~229 string refs** (`this.refs.X`): deprecated but functional in
+         React 18, **removed in React 19** — so React 19 is gated on migrating
+         all of them to callback refs / `createRef`. Target React 18 first.
 3. [ ] **Electron 4 → latest** — the largest change: arm64 support, context
        isolation, `remote` module removal, `nodeIntegration` review, native
        module rebuilds, and security-model changes. Also unblocks running the


### PR DESCRIPTION
## 概要
React モダナイズの障壁を実測監査し、ロードマップに記録します。

## 監査結果（2026-06）
- **クラスライフサイクルは既に `UNSAFE_` プレフィックス済み**（bare な `componentWillMount` 等は 0）→ React 18 まで動作
- **`ReactDOM.render` は 2 箇所のみ** → `createRoot` 移行は軽微
- **string refs（`this.refs.X`）が ~229 箇所** → React 18 では deprecated だが動作、**React 19 で削除**

→ **React 16 → 18 は現実的**。React 19 は 229 箇所の string ref 移行が前提。まず 18 を狙う。

docs のみ。
🤖 Generated with [Claude Code](https://claude.com/claude-code)