### PR TITLE
test: add tests for ColorPicker and StorageList (batch 3)

### DIFF
--- a/tests/components/ColorPicker.test.js
+++ b/tests/components/ColorPicker.test.js
@@ -1,0 +1,46 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import ColorPicker from 'browser/components/ColorPicker'
+
+const baseProps = {
+  color: '#ff0000',
+  targetRect: { right: 100, top: 50, bottom: 80 },
+  onConfirm: jest.fn(),
+  onCancel: jest.fn(),
+  onReset: jest.fn()
+}
+
+it('ColorPicker renders', () => {
+  const component = renderer.create(<ColorPicker {...baseProps} />)
+  expect(component.toJSON()).toBeTruthy()
+})
+
+it('ColorPicker confirms with the current color', () => {
+  const onConfirm = jest.fn()
+  const component = renderer.create(
+    <ColorPicker {...baseProps} onConfirm={onConfirm} />
+  )
+  component.root.findByProps({ className: 'btn-confirm' }).props.onClick()
+  expect(onConfirm).toHaveBeenCalledWith('#ff0000')
+})
+
+it('ColorPicker calls onReset and onCancel from their buttons', () => {
+  const onReset = jest.fn()
+  const onCancel = jest.fn()
+  const component = renderer.create(
+    <ColorPicker {...baseProps} onReset={onReset} onCancel={onCancel} />
+  )
+  component.root.findByProps({ className: 'btn-reset' }).props.onClick()
+  component.root.findByProps({ className: 'btn-cancel' }).props.onClick()
+  expect(onReset).toHaveBeenCalledTimes(1)
+  expect(onCancel).toHaveBeenCalledTimes(1)
+})
+
+it('ColorPicker defaults the color when none is given', () => {
+  const onConfirm = jest.fn()
+  const component = renderer.create(
+    <ColorPicker {...baseProps} color={undefined} onConfirm={onConfirm} />
+  )
+  component.root.findByProps({ className: 'btn-confirm' }).props.onClick()
+  expect(onConfirm).toHaveBeenCalledWith('#939395')
+})

--- a/tests/components/StorageList.test.js
+++ b/tests/components/StorageList.test.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import StorageList from 'browser/components/StorageList'
+
+it('StorageList shows the empty message when there are no storages', () => {
+  const tree = renderer
+    .create(<StorageList storageList={[]} isFolded={false} />)
+    .toJSON()
+  expect(tree.props.className).toBe('storageList')
+  expect(JSON.stringify(tree)).toContain('No storage mount.')
+})
+
+it('StorageList uses the folded class when folded', () => {
+  const tree = renderer
+    .create(<StorageList storageList={[]} isFolded />)
+    .toJSON()
+  expect(tree.props.className).toBe('storageList-folded')
+})
+
+it('StorageList renders the provided storages', () => {
+  const items = [<div key='a'>StorageA</div>, <div key='b'>StorageB</div>]
+  const tree = renderer
+    .create(<StorageList storageList={items} isFolded={false} />)
+    .toJSON()
+  expect(JSON.stringify(tree)).toContain('StorageA')
+  expect(JSON.stringify(tree)).not.toContain('No storage mount.')
+})


### PR DESCRIPTION
## 概要
コンポーネントテスト第3弾。

| コンポーネント | テスト内容 |
|---|---|
| ColorPicker | 描画 / Confirm で現在色を `onConfirm` / Reset・Cancel handler / 色未指定時は `#939395` |
| StorageList | 空状態メッセージ / folded クラス切替 / 渡された storage 要素を描画 |

Jest: **144 → 151 passing**（+7）、コンポーネントテスト 7 → 9。テストのみ。
🤖 Generated with [Claude Code](https://claude.com/claude-code)