### PR TITLE
test: add unit tests for convertModeName and Mutable utilities

### DIFF
--- a/tests/lib/Mutable.test.js
+++ b/tests/lib/Mutable.test.js
@@ -1,0 +1,54 @@
+const Mutable = require('browser/lib/Mutable')
+
+describe('Mutable.Map', () => {
+  it('wraps a Map with get/set/has/delete/size', () => {
+    const m = new Mutable.Map([['a', 1]])
+    expect(m.get('a')).toBe(1)
+    expect(m.has('a')).toBe(true)
+    expect(m.size).toBe(1)
+
+    m.set('b', 2)
+    expect(m.get('b')).toBe(2)
+    expect(m.size).toBe(2)
+
+    m.delete('a')
+    expect(m.has('a')).toBe(false)
+  })
+
+  it('map() returns an array of callback results', () => {
+    const m = new Mutable.Map([
+      ['a', 1],
+      ['b', 2]
+    ])
+    expect(m.map((value, key) => `${key}:${value}`).sort()).toEqual([
+      'a:1',
+      'b:2'
+    ])
+  })
+
+  it('toJS() returns a plain object and converts nested mutables', () => {
+    const m = new Mutable.Map([
+      ['a', 1],
+      ['s', new Mutable.Set([1, 2])]
+    ])
+    expect(m.toJS()).toEqual({ a: 1, s: [1, 2] })
+  })
+})
+
+describe('Mutable.Set', () => {
+  it('wraps a Set with add/delete/size', () => {
+    const s = new Mutable.Set([1])
+    expect(s.size).toBe(1)
+
+    s.add(2)
+    expect(s.size).toBe(2)
+
+    s.delete(1)
+    expect(s.size).toBe(1)
+  })
+
+  it('toJS() returns an array of the values', () => {
+    const s = new Mutable.Set([1, 2, 3])
+    expect(s.toJS().sort()).toEqual([1, 2, 3])
+  })
+})

--- a/tests/lib/convertModeName.test.js
+++ b/tests/lib/convertModeName.test.js
@@ -1,0 +1,14 @@
+import convertModeName from 'browser/lib/convertModeName'
+
+it('maps known CodeMirror mode names to display names', () => {
+  expect(convertModeName('ejs')).toBe('Embedded Javascript')
+  expect(convertModeName('html_ruby')).toBe('Embedded Ruby')
+  expect(convertModeName('objectivec')).toBe('Objective C')
+  expect(convertModeName('text')).toBe('Plain Text')
+})
+
+it('returns the name unchanged for unknown modes', () => {
+  expect(convertModeName('javascript')).toBe('javascript')
+  expect(convertModeName('python')).toBe('python')
+  expect(convertModeName('')).toBe('')
+})


### PR DESCRIPTION
## 概要
未テストの純粋ユーティリティ2件にユニットテストを追加。

| モジュール | テスト内容 |
|---|---|
| convertModeName | 既知の CodeMirror モード→表示名のマッピング / 未知モードはそのまま返す |
| Mutable (Map/Set ラッパー) | get/set/has/delete/size / `map()` / `toJS()`（ネストした mutable の変換含む） |

Jest: **151 → 158 passing**（+7）。テストのみ。
🤖 Generated with [Claude Code](https://claude.com/claude-code)