### PR TITLE
test: add unit tests for markdownTextHelper.strip

### DIFF
--- a/tests/lib/markdownTextHelper.test.js
+++ b/tests/lib/markdownTextHelper.test.js
@@ -1,0 +1,32 @@
+import { strip } from 'browser/lib/markdownTextHelper'
+
+it('strips heading markers', () => {
+  expect(strip('# Heading')).toBe('Heading')
+  expect(strip('### Sub heading')).toBe('Sub heading')
+})
+
+it('strips inline code backticks', () => {
+  expect(strip('`code`')).toBe('code')
+})
+
+it('strips strikethrough markers', () => {
+  expect(strip('~~text~~')).toBe('text')
+})
+
+it('strips list markers', () => {
+  expect(strip('- item')).toBe('item')
+  expect(strip('+ item')).toBe('item')
+  expect(strip('1. item')).toBe('item')
+})
+
+it('strips link syntax but keeps the label', () => {
+  expect(strip('[label](http://example.com)')).toBe('label')
+})
+
+it('collapses runs of blank lines', () => {
+  expect(strip('a\n\n\n\nb')).toBe('a\n\nb')
+})
+
+it('returns the input unchanged when it cannot be processed', () => {
+  expect(strip(null)).toBe(null)
+})


### PR DESCRIPTION
## 概要
ノートのプレビュー/タイトル生成に使われる markdown トリマー `strip` のテストを追加。

カバー: 見出し / インラインコード / 取り消し線 / リストマーカー除去、リンクラベル抽出、空行の集約、エラー時のパススルー。

Jest: **158 → 165 passing**（+7）。テストのみ。
🤖 Generated with [Claude Code](https://claude.com/claude-code)