### PR TITLE
test: add unit tests for dataApi/getFilename

### DIFF
--- a/tests/dataApi/getFilename.test.js
+++ b/tests/dataApi/getFilename.test.js
@@ -1,0 +1,30 @@
+const path = require('path')
+const getFilename = require('browser/main/lib/dataApi/getFilename')
+
+it('builds a filename from the note title', () => {
+  expect(getFilename({ title: 'My Note' }, 'md', '/out')).toBe(
+    path.join('/out', 'My Note.md')
+  )
+})
+
+it('sanitizes path separators in the title', () => {
+  expect(getFilename({ title: 'a/b' }, 'md', '/out')).toBe(
+    path.join('/out', 'a_b.md')
+  )
+})
+
+it('falls back to a default name when the note has no title', () => {
+  const result = getFilename({ title: '' }, 'md', '/out')
+  expect(result.startsWith(path.join('/out', ''))).toBe(true)
+  expect(result.endsWith('.md')).toBe(true)
+})
+
+it('deduplicates repeated filenames with an incrementing suffix', () => {
+  const deduplicator = {}
+  const first = getFilename({ title: 'Dup' }, 'md', '/out', deduplicator)
+  const second = getFilename({ title: 'Dup' }, 'md', '/out', deduplicator)
+  const third = getFilename({ title: 'Dup' }, 'md', '/out', deduplicator)
+  expect(first).toBe(path.join('/out', 'Dup.md'))
+  expect(second).toBe(path.join('/out', 'Dup (1).md'))
+  expect(third).toBe(path.join('/out', 'Dup (2).md'))
+})


### PR DESCRIPTION
## 概要
エクスポート用ファイル名生成 `getFilename` のテストを追加。

- タイトル → ファイル名
- 不正文字（パス区切り）のサニタイズ
- タイトル無しの既定名フォールバック
- **重複名の dedup**（`(1)`, `(2)` … と連番付与）

Jest: **171 → 175 passing**（+4）。テストのみ。
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * ファイル名生成のルールを検証するユニットテストを追加しました。
  * タイトルからのファイル名組み立て、区切り文字の置換、空タイトル時の既定名、重複時の連番付き回避が確認されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->