### PR TITLE
test: add unit tests for dataApi/resolveStorageNotes

### DIFF
--- a/tests/dataApi/resolveStorageNotes.test.js
+++ b/tests/dataApi/resolveStorageNotes.test.js
@@ -1,0 +1,33 @@
+const os = require('os')
+const fs = require('fs')
+const path = require('path')
+const sander = require('sander')
+const CSON = require('@rokt33r/season')
+const resolveStorageNotes = require('browser/main/lib/dataApi/resolveStorageNotes')
+
+const storagePath = path.join(os.tmpdir(), 'boostnote-test-resolveStorageNotes')
+
+afterEach(() => {
+  sander.rimrafSync(storagePath)
+})
+
+it('returns an empty list and creates the notes dir when it is missing', () => {
+  return resolveStorageNotes({ key: 's1', path: storagePath }).then(notes => {
+    expect(notes).toEqual([])
+    expect(fs.existsSync(path.join(storagePath, 'notes'))).toBe(true)
+  })
+})
+
+it('parses .cson notes and attaches the key and storage', () => {
+  const notesDir = path.join(storagePath, 'notes')
+  sander.mkdirSync(notesDir)
+  CSON.writeFileSync(path.join(notesDir, 'abc.cson'), { title: 'Hello' })
+  fs.writeFileSync(path.join(notesDir, 'ignore.txt'), 'not a note')
+
+  return resolveStorageNotes({ key: 's1', path: storagePath }).then(notes => {
+    expect(notes.length).toBe(1)
+    expect(notes[0].title).toBe('Hello')
+    expect(notes[0].key).toBe('abc')
+    expect(notes[0].storage).toBe('s1')
+  })
+})


### PR DESCRIPTION
## 概要
ストレージのノート解決 `resolveStorageNotes` のテストを一時ディレクトリで追加。

- notes ディレクトリが無い → 空リスト + ディレクトリ作成
- `.cson` ノートをパースし `key`（ファイル名）と `storage` を付与、非 `.cson` は無視

Jest: **175 → 177 passing**（+2）。テストのみ。
🤖 Generated with [Claude Code](https://claude.com/claude-code)