### PR TITLE
test: add unit tests for markdown-it-sanitize-html (XSS protection)

### DIFF
--- a/tests/lib/markdown-it-sanitize-html.test.js
+++ b/tests/lib/markdown-it-sanitize-html.test.js
@@ -1,0 +1,30 @@
+const MarkdownIt = require('markdown-it')
+const sanitize = require('browser/lib/markdown-it-sanitize-html')
+
+const options = {
+  allowedTags: ['b', 'i', 'em', 'strong', 'a', 'p', 'br'],
+  allowedAttributes: { '*': ['href', 'title'] },
+  selfClosing: ['img', 'br', 'hr', 'input'],
+  allowedSchemes: ['http', 'https', 'ftp', 'mailto'],
+  allowedSchemesAppliedToAttributes: ['href', 'src', 'cite']
+}
+
+const render = src =>
+  new MarkdownIt({ html: true }).use(sanitize, options).render(src)
+
+it('strips disallowed html blocks such as <script>', () => {
+  const html = render('<script>alert(1)</script>')
+  expect(html).not.toContain('<script>')
+  expect(html).not.toContain('alert(1)')
+})
+
+it('keeps allowed html block tags', () => {
+  const html = render('<p>kept</p>')
+  expect(html).toContain('kept')
+})
+
+it('escapes html inside fenced code blocks', () => {
+  const html = render('```\n<script>x</script>\n```')
+  expect(html).not.toContain('<script>x</script>')
+  expect(html).toContain('&lt;script&gt;')
+})


### PR DESCRIPTION
## 概要
XSS 防御プラグイン `markdown-it-sanitize-html` のテストを追加（セキュリティ関連）。

- 不許可の html ブロック（`<script>` 等）を除去
- 許可タグ（`<p>` 等）は保持
- コードフェンス内の html はエスケープ（実行されない）

完全な options オブジェクトを渡して検証。Jest: **182 → 185 passing**（+3）。テストのみ。
🤖 Generated with [Claude Code](https://claude.com/claude-code)