### PR TITLE
test: add unit tests for the Commander command dispatcher

### DIFF
--- a/tests/lib/Commander.test.js
+++ b/tests/lib/Commander.test.js
@@ -1,0 +1,33 @@
+import Commander from 'browser/main/lib/Commander'
+
+it('fires the command on bound elements matching the target', () => {
+  const el = { fire: jest.fn() }
+  Commander.bind('editor', el)
+  Commander.fire('editor:save')
+  expect(el.fire).toHaveBeenCalledWith('save')
+  Commander.release(el)
+})
+
+it('does not fire released elements', () => {
+  const el = { fire: jest.fn() }
+  Commander.bind('editor', el)
+  Commander.release(el)
+  Commander.fire('editor:save')
+  expect(el.fire).not.toHaveBeenCalled()
+})
+
+it('fires every element bound to the same target', () => {
+  const a = { fire: jest.fn() }
+  const b = { fire: jest.fn() }
+  Commander.bind('list', a)
+  Commander.bind('list', b)
+  Commander.fire('list:refresh')
+  expect(a.fire).toHaveBeenCalledWith('refresh')
+  expect(b.fire).toHaveBeenCalledWith('refresh')
+  Commander.release(a)
+  Commander.release(b)
+})
+
+it('ignores commands with no matching target', () => {
+  expect(() => Commander.fire('nothing:here')).not.toThrow()
+})


### PR DESCRIPTION
## 概要
エディタコマンドの pub/sub ディスパッチャ `Commander`（bind/fire/release）のテストを追加。

- `fire('target:command')` が bind 済み要素の `fire('command')` を呼ぶ
- release した要素には届かない
- 同一 target の全要素に発火
- 一致しない target は no-op

Jest: **185 → 189 passing**（+4）。テストのみ。
🤖 Generated with [Claude Code](https://claude.com/claude-code)