### PR TITLE
test: add unit tests for the keyboard shortcut event map

### DIFF
--- a/tests/lib/shortcut.test.js
+++ b/tests/lib/shortcut.test.js
@@ -1,0 +1,18 @@
+import ee from 'browser/main/lib/eventEmitter'
+import shortcut from 'browser/main/lib/shortcut'
+
+const cases = [
+  ['toggleMode', 'topbar:togglemodebutton'],
+  ['toggleDirection', 'topbar:toggledirectionbutton'],
+  ['deleteNote', 'hotkey:deletenote'],
+  ['toggleMenuBar', 'menubar:togglemenubar']
+]
+
+cases.forEach(([fn, event]) => {
+  it(`${fn} emits "${event}"`, () => {
+    const spy = jest.spyOn(ee, 'emit').mockImplementation(() => {})
+    shortcut[fn]()
+    expect(spy).toHaveBeenCalledWith(event)
+    spy.mockRestore()
+  })
+})


### PR DESCRIPTION
## 概要
ショートカット → eventEmitter のイベント名の対応をテスト（typo ガード）。

`toggleMode` / `toggleDirection` / `deleteNote` / `toggleMenuBar` が期待イベントを emit することを検証。

Jest: **189 → 193 passing**（+4）。テストのみ。
🤖 Generated with [Claude Code](https://claude.com/claude-code)