### PR TITLE
refactor: extract config/status reducers for testability + add tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ node_modules/
 compiled/
 dist/
 extra_scripts/
+coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ config.json
 # Local-only Claude Code config / private project notes
 .claude/settings.local.json
 CLAUDE.local.md
+
+coverage/

--- a/browser/main/configReducer.js
+++ b/browser/main/configReducer.js
@@ -1,0 +1,40 @@
+// The config reducer's initial state comes from ConfigManager (which needs
+// electron), so it is built as a factory that receives the default config.
+// This keeps the reducer logic free of electron and unit-testable.
+export function createConfigReducer(defaultConfig) {
+  return function config(state = defaultConfig, action) {
+    switch (action.type) {
+      case 'SET_IS_SIDENAV_FOLDED':
+        state.isSideNavFolded = action.isFolded
+        return Object.assign({}, state)
+      case 'SET_ZOOM':
+        state.zoom = action.zoom
+        return Object.assign({}, state)
+      case 'SET_LIST_WIDTH':
+        state.listWidth = action.listWidth
+        return Object.assign({}, state)
+      case 'SET_NAV_WIDTH':
+        state.navWidth = action.navWidth
+        return Object.assign({}, state)
+      case 'SET_CONFIG':
+        return Object.assign({}, state, action.config)
+      case 'SET_UI':
+        return Object.assign({}, state, action.config)
+    }
+    return state
+  }
+}
+
+export const defaultStatus = {
+  updateReady: false
+}
+
+export function status(state = defaultStatus, action) {
+  switch (action.type) {
+    case 'UPDATE_AVAILABLE':
+      return Object.assign({}, defaultStatus, {
+        updateReady: true
+      })
+  }
+  return state
+}

--- a/browser/main/store.js
+++ b/browser/main/store.js
@@ -4,44 +4,9 @@ import { createHashHistory as createHistory } from 'history'
 import ConfigManager from 'browser/main/lib/ConfigManager'
 import DevTools from './DevTools'
 import { data } from './dataReducer'
+import { createConfigReducer, status } from './configReducer'
 
-const defaultConfig = ConfigManager.get()
-
-function config(state = defaultConfig, action) {
-  switch (action.type) {
-    case 'SET_IS_SIDENAV_FOLDED':
-      state.isSideNavFolded = action.isFolded
-      return Object.assign({}, state)
-    case 'SET_ZOOM':
-      state.zoom = action.zoom
-      return Object.assign({}, state)
-    case 'SET_LIST_WIDTH':
-      state.listWidth = action.listWidth
-      return Object.assign({}, state)
-    case 'SET_NAV_WIDTH':
-      state.navWidth = action.navWidth
-      return Object.assign({}, state)
-    case 'SET_CONFIG':
-      return Object.assign({}, state, action.config)
-    case 'SET_UI':
-      return Object.assign({}, state, action.config)
-  }
-  return state
-}
-
-const defaultStatus = {
-  updateReady: false
-}
-
-function status(state = defaultStatus, action) {
-  switch (action.type) {
-    case 'UPDATE_AVAILABLE':
-      return Object.assign({}, defaultStatus, {
-        updateReady: true
-      })
-  }
-  return state
-}
+const config = createConfigReducer(ConfigManager.get())
 
 const history = createHistory()
 

--- a/tests/configReducer.test.js
+++ b/tests/configReducer.test.js
@@ -1,0 +1,65 @@
+import {
+  createConfigReducer,
+  status,
+  defaultStatus
+} from 'browser/main/configReducer'
+
+describe('config reducer', () => {
+  const config = createConfigReducer({ zoom: 1, isSideNavFolded: false })
+
+  it('returns the injected default state initially', () => {
+    expect(config(undefined, { type: '@@INIT' })).toEqual({
+      zoom: 1,
+      isSideNavFolded: false
+    })
+  })
+
+  it('SET_ZOOM updates the zoom', () => {
+    expect(config({ zoom: 1 }, { type: 'SET_ZOOM', zoom: 2 }).zoom).toBe(2)
+  })
+
+  it('SET_IS_SIDENAV_FOLDED updates the fold flag', () => {
+    const result = config(
+      { isSideNavFolded: false },
+      { type: 'SET_IS_SIDENAV_FOLDED', isFolded: true }
+    )
+    expect(result.isSideNavFolded).toBe(true)
+  })
+
+  it('SET_CONFIG merges the provided config', () => {
+    expect(config({ a: 1 }, { type: 'SET_CONFIG', config: { b: 2 } })).toEqual({
+      a: 1,
+      b: 2
+    })
+  })
+
+  it('SET_UI merges the provided config', () => {
+    expect(
+      config({ a: 1 }, { type: 'SET_UI', config: { theme: 'dark' } }).theme
+    ).toBe('dark')
+  })
+
+  it('returns the same state for an unknown action', () => {
+    const state = { zoom: 1 }
+    expect(config(state, { type: 'NOPE' })).toBe(state)
+  })
+})
+
+describe('status reducer', () => {
+  it('defaults to not-ready', () => {
+    expect(status(undefined, { type: '@@INIT' })).toEqual({
+      updateReady: false
+    })
+  })
+
+  it('UPDATE_AVAILABLE marks the update ready', () => {
+    expect(status(defaultStatus, { type: 'UPDATE_AVAILABLE' })).toEqual({
+      updateReady: true
+    })
+  })
+
+  it('returns the same state for an unknown action', () => {
+    const state = { updateReady: false }
+    expect(status(state, { type: 'NOPE' })).toBe(state)
+  })
+})


### PR DESCRIPTION
## 概要
data reducer に続き、`config` / `status` reducer を `store.js` から切り出してテスト可能にします（store.js は ConfigManager 経由で electron を引くため jest 不可）。

## 変更
- `config` reducer は初期状態が ConfigManager 由来のため、**ファクトリ `createConfigReducer(default)`** として export。store.js が `ConfigManager.get()` を注入 → ロジックは electron フリーに
- `status` reducer は純粋なのでそのまま移動
- テスト追加: config（SET_ZOOM / SET_IS_SIDENAV_FOLDED / SET_CONFIG / SET_UI / 既定 / 未知アクション素通し）、status（既定 / UPDATE_AVAILABLE / 素通し）
- 生成物 `coverage/` を gitignore + eslintignore（`jest --coverage` が git/lint を汚さないように）

## 検証
- ✅ webpack 本番ビルド コンパイル成功
- ✅ フルスイート green（**209 → 218**）、lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)