### PR TITLE
ci: print a Jest coverage summary on every run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,9 @@ jobs:
         run: npm run ava
 
       - name: Jest
-        run: npx jest --ci
+        # --coverage prints a coverage summary for the code exercised by the
+        # tests (informational; no threshold is enforced).
+        run: npx jest --ci --coverage --coverageReporters=text-summary
 
       - name: Build (webpack production)
         # webpack 1 exits 0 even on compilation errors, so use --bail to fail


### PR DESCRIPTION
## 概要
CI の Jest ステップに `--coverage --coverageReporters=text-summary` を追加し、テストが通過したコードのカバレッジをログに表示します（現状 **~71% statements / ~72% lines**）。

- **情報表示のみ**（しきい値なし）→ ビルドを flaky にしない
- これまでに構築したテストの成果を可視化・追跡可能に

🤖 Generated with [Claude Code](https://claude.com/claude-code)