### PR TITLE
docs: update readme badge and build docs to the current setup

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -5,23 +5,23 @@ This page is also available in [Japanese](https://github.com/BoostIO/Boostnote/b
 ## Environments
 
 - npm: 6.x
-- node: 8.x
+- node: 14.x (see `.nvmrc` / the Volta pin in `package.json`)
 
 ## Development
 
 We use Webpack HMR to develop Boostnote.
 Running the following commands, at the top of the project directory, will start Boostnote with the default configurations.
 
-Install the required packages using yarn.
+Install the required packages using npm.
 
 ```
-$ yarn
+$ npm install
 ```
 
 Build and run.
 
 ```
-$ yarn run dev
+$ npm run dev
 ```
 
 > ### Notice
@@ -55,8 +55,8 @@ git checkout <PR>
 
 _To compile and run the code_
 ```
-yarn
-yarn run dev
+npm install
+npm run dev
 ```
 
 ## Deploy
@@ -83,7 +83,7 @@ Distribution packages are created by exec `grunt build` on Linux platform (e.g. 
 After installing the supported version of `node` and `npm`, install build dependency packages.
 
 ```
-$ yarn add --dev grunt-electron-installer-debian grunt-electron-installer-redhat
+$ npm install --save-dev grunt-electron-installer-debian grunt-electron-installer-redhat
 ```
 
 **Ubuntu/Debian:**

--- a/readme.md
+++ b/readme.md
@@ -26,8 +26,8 @@
 <h5 align="center">Apps available for Mac, Windows and Linux.</h5>
 <h5 align="center">Built with Electron, React + Redux, Webpack, and CSSModules.</h5>
 <p align="center">
-  <a href="https://travis-ci.org/BoostIO/Boostnote">
-    <img src="https://travis-ci.org/BoostIO/Boostnote.svg?branch=master" alt="Build Status" />
+  <a href="https://github.com/BoxPistols/Boostnote/actions/workflows/ci.yml">
+    <img src="https://github.com/BoxPistols/Boostnote/actions/workflows/ci.yml/badge.svg" alt="CI Status" />
   </a>
  </p>
 


### PR DESCRIPTION
## 概要
ドキュメントを**現在の実構成**に合わせて更新（古いツールチェーン記述の修正）。

- **readme**: 死んだ Travis CI バッジ（BoostIO/master）→ 本 fork の **GitHub Actions CI バッジ**
- **build.md**: `yarn` → `npm`（`npm install` / `npm run dev` / `npm install --save-dev ...`）、node **8.x → 14.x**（`.nvmrc` / Volta pin に整合）

docs のみ。
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 開発環境と手順の案内を更新し、`yarn` ベースから `npm` ベースへ切り替えました。
  * 必要な Node.js バージョンの記載を新しい環境に合わせて更新しました。
  * ローカル起動や配布パッケージ作成の手順を、最新のコマンドに修正しました。
* **Chores**
  * CI バッジを GitHub Actions のものに差し替えました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->