### PR TITLE
fix(security): avoid shell command injection in the WakaTime plugin

### DIFF
--- a/browser/lib/wakatime-plugin.js
+++ b/browser/lib/wakatime-plugin.js
@@ -1,5 +1,5 @@
 import config from 'browser/main/lib/ConfigManager'
-const exec = require('child_process').exec
+const execFile = require('child_process').execFile
 const path = require('path')
 let lastHeartbeat = 0
 
@@ -23,8 +23,22 @@ function sendWakatimeHeartBeat(
     lastHeartbeat = new Date()
     const wakatimeKey = config.get().wakatime.key
     if (wakatimeKey) {
-      exec(
-        `wakatime --file ${notePath} --project '${storageName}' --key ${wakatimeKey}  --plugin Boostnote-wakatime`,
+      // Use execFile with an argument array (no shell) so user-controlled
+      // values (storage path/name, key) cannot be interpreted as shell
+      // syntax. Passing them via `exec` with string interpolation is a
+      // command-injection risk and also breaks on paths containing spaces.
+      execFile(
+        'wakatime',
+        [
+          '--file',
+          notePath,
+          '--project',
+          storageName,
+          '--key',
+          wakatimeKey,
+          '--plugin',
+          'Boostnote-wakatime'
+        ],
         (error, stdOut, stdErr) => {
           if (error) {
             console.log(error)


### PR DESCRIPTION
## 🔒 概要（セキュリティ修正）
WakaTime 連携の `sendWakatimeHeartBeat` が、**ユーザー制御値**（ストレージのパス・名前・APIキー）を `exec(...)` のシェルコマンド文字列に直接補間していました：

```js
exec(`wakatime --file ${notePath} --project '${storageName}' --key ${wakatimeKey} ...`)
```

ストレージのパスや名前にシェルメタ文字（あるいは**空白**）が含まれると、コマンドが壊れる/**任意シェルが注入**されます（= WakaTime 連携 ON 時のコマンド実行）。

## 修正
`execFile('wakatime', [..args])` に変更。引数配列をシェルを介さずプロセスへ直接渡すため、ユーザー値がシェル構文として解釈されません（空白を含むパスも正しく動作）。

## 検証
- lint clean / フルスイート green（218）/ 本番ビルド コンパイル成功
- 本モジュールは ConfigManager(electron) を import するため jest 単体テスト不可。`exec`→`execFile` は意図された呼び出しに対して挙動同等です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)