### PR TITLE
fix: replace deprecated new Buffer() and guard with a lint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,7 +23,8 @@
       "closingSlash": "allow",
       "afterOpening": "allow",
       "beforeClosing": "allow"
-    }]
+    }],
+    "no-buffer-constructor": "error"
   },
   "globals": {
     "FileReader": true,

--- a/browser/main/lib/dataApi/attachmentManagement.js
+++ b/browser/main/lib/dataApi/attachmentManagement.js
@@ -493,7 +493,7 @@ function handlePasteImageEvent(
   reader.onloadend = function() {
     base64data = reader.result.replace(/^data:image\/png;base64,/, '')
     base64data += base64data.replace('+', ' ')
-    const binaryData = new Buffer(base64data, 'base64').toString('binary')
+    const binaryData = Buffer.from(base64data, 'base64').toString('binary')
     fs.writeFileSync(imagePath, binaryData, 'binary')
     const imageReferencePath = path.join(
       STORAGE_FOLDER_PLACEHOLDER,


### PR DESCRIPTION
## 概要
Node が非推奨とした `new Buffer()` コンストラクタ（誤用しやすく、数値形式では未初期化メモリ露出の恐れ）を修正し、再発をlintで防止します。

- 唯一の使用箇所（貼り付け画像の base64 デコード, attachmentManagement）→ `Buffer.from(base64data, 'base64')`
- ESLint `no-buffer-constructor` を `error` で有効化 → 今後の使用は CI で失敗

## 検証
lint clean / フルスイート green（218）/ 本番ビルド コンパイル成功。
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 画像の貼り付け処理で、base64変換時の互換性と安定性を改善しました。
* **Chores**
  * コード品質ルールを更新し、非推奨な記述を避けるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->