### PR TITLE
chore: enable bug-catching ESLint rules the codebase already passes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,7 +24,10 @@
       "afterOpening": "allow",
       "beforeClosing": "allow"
     }],
-    "no-buffer-constructor": "error"
+    "no-buffer-constructor": "error",
+    "no-self-compare": "error",
+    "no-unmodified-loop-condition": "error",
+    "no-template-curly-in-string": "error"
   },
   "globals": {
     "FileReader": true,


### PR DESCRIPTION
## 概要
コードベースが**既にクリーンに通る**（0 違反確認済み）バグ検出ルールを有効化し、潜在バグ3クラスを CI で恒久ガード。

- `no-self-compare` — `x === x` 等の誤り
- `no-unmodified-loop-condition` — ループ条件が更新されない（無限ループ）
- `no-template-curly-in-string` — 通常文字列に `'${x}'` を書いた誤り

いずれも継承元 `standard@6` には無く、新規カバレッジを追加。今後の混入を CI が検出します。
🤖 Generated with [Claude Code](https://claude.com/claude-code)