### PR TITLE
fix: index ADD_STORAGE notes into storageNoteMap (not tagNoteMap)

### DIFF
--- a/browser/main/dataReducer.js
+++ b/browser/main/dataReducer.js
@@ -292,7 +292,10 @@ export function data(state = defaultDataMap(), action) {
           state.starredSet.add(uniqueKey)
         }
 
-        const storageNoteList = getOrInitItem(state.tagNoteMap, note.storage)
+        const storageNoteList = getOrInitItem(
+          state.storageNoteMap,
+          note.storage
+        )
         storageNoteList.add(uniqueKey)
 
         let folderNoteSet = state.folderNoteMap.get(folderKey)

--- a/tests/dataReducerActions.test.js
+++ b/tests/dataReducerActions.test.js
@@ -41,6 +41,18 @@ it('REMOVE_STORAGE removes the storage and its notes', () => {
   expect(state.noteMap.has('n1')).toBe(false)
 })
 
+it('ADD_STORAGE indexes its notes into storageNoteMap, not tagNoteMap', () => {
+  const state = data(defaultDataMap(), {
+    type: 'ADD_STORAGE',
+    storage: { key: 's1' },
+    notes: [makeNote({ key: 'n1', storage: 's1' })]
+  })
+  // The note must be registered under the storage's note set...
+  expect(state.storageNoteMap.get('s1').toJS()).toContain('n1')
+  // ...and the tag map must not be polluted with a storage-keyed entry.
+  expect(state.tagNoteMap.has('s1')).toBe(false)
+})
+
 it('DELETE_FOLDER removes the folder index and its notes', () => {
   let state = initWith(
     [{ key: 's1', folders: [{ key: 'f1' }] }],


### PR DESCRIPTION
## 概要
`ADD_STORAGE` reducer が、各ノートを `storageNoteMap[note.storage]` ではなく **`tagNoteMap[note.storage]`** に登録していました（コピペミス。変数名は `storageNoteList`、INIT_ALL は正しく storageNoteMap）。

## 影響
実行時に既存ノートを持つストレージを追加すると、ノートが storageNoteMap（直前で作られた空 Set のまま）に入らず、**ストレージのノート件数/一覧が次のフルリロード（INIT_ALL）まで不正**に。加えて tagNoteMap が storage キーのエントリで汚染されていました。

## 検証
- **テスト駆動**で発見・修正（回帰テストは旧コードで失敗・修正後 pass）
- 全 reducer テスト pass、本番ビルド コンパイル成功
- Jest: **218 → 219 passing**

この修正は、先の reducer 切り出し（テスト可能化）によって発見・検証が可能になりました。
🤖 Generated with [Claude Code](https://claude.com/claude-code)