### PR TITLE
fix: pin js-message to 1.x so the app starts (ESM crash on launch)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9266,9 +9266,9 @@
       "dev": true
     },
     "js-message": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/js-message/-/js-message-2.1.0.tgz",
-      "integrity": "sha512-A35DTK9pQF5Pnf7U2I++QlkO7W+lvMrDubOyF/6g6UaeXOIYqCV7TFEIxA3zOjqbQHyXHOnMtGdmQBnGJ2axeA=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/js-message/-/js-message-1.0.7.tgz",
+      "integrity": "sha512-efJLHhLjIyKRewNS9EGZ4UpI8NguuL6fKkhRxVuMmrGV2xN/0APGdQYwLFky5w9naebSZ0OwAGp0G6/2Cg90rA=="
     },
     "js-queue": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "iconv-lite": "^0.4.19",
     "immutable": "^3.8.1",
     "invert-color": "^2.0.0",
+    "js-message": "^1.0.7",
     "js-yaml": "^3.13.1",
     "jsonlint-mod": "^1.7.4",
     "katex": "^0.10.1",


### PR DESCRIPTION
## 🔴 概要（アプリ起動不能の修正）
アプリ起動時にメインプロセスで即クラッシュしていました：

```
node_modules/js-message/Message.js:1
export class Message {
^^^^^^
SyntaxError: Unexpected token export
```

`node-ipc@8.x` が `js-message: ">=1.0.5"` という緩い範囲で依存しており、これが **ES モジュール化された js-message 2.x** を取り込んでいました。Electron 4 の Node は node-ipc/js-message を CommonJS `require` で読むため、トップレベル `export` を解釈できず**ウィンドウが一切開かない**状態でした。

## 修正
`js-message@^1.0.5`（→ 1.0.7、node-ipc 8.x が前提としていた CommonJS 系）を直接依存に固定し、node-ipc がこれを解決するようにします。

## 検証（実機でアプリ起動）
`electron ./index.js` で**実際に起動確認**：以前は SyntaxError でウィンドウ表示前にクラッシュ → 修正後は**メイン+レンダラープロセスが正常起動・例外なし**。lint clean / テスト green。

## 補足
CI はこれを検出できませんでした（CI は lint/ava/jest/webpack ビルドのみで、Electron を起動しない）。本障害は webpack 外・実行時のメインプロセスで発生します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)