### PR TITLE
fix(dev): handle async rejection from devtools extension install

### DIFF
--- a/lib/main-window.js
+++ b/lib/main-window.js
@@ -25,11 +25,13 @@ if (process.env.NODE_ENV === 'development') {
   const extensions = [REACT_DEVELOPER_TOOLS, REACT_PERF, ChromeLens]
 
   for (const extension of extensions) {
-    try {
-      installExtension(extension)
-    } catch (e) {
+    // installExtension returns a Promise; a try/catch can't catch its async
+    // rejection, so a failed devtools download (e.g. cross-unzip exit code 9)
+    // previously surfaced as a noisy UnhandledPromiseRejection on every dev
+    // launch. Attach .catch() to handle it gracefully.
+    Promise.resolve(installExtension(extension)).catch(e => {
       console.error(`[ELECTRON] Extension installation failed`, e)
-    }
+    })
   }
 }
 


### PR DESCRIPTION
## What

`installExtension()` (electron-devtools-installer) returns a **Promise**, but the call in `lib/main-window.js` was wrapped in a `try/catch` that only catches synchronous throws. The async rejection escaped it.

## Symptom

On every `npm run dev` launch, the DevTools extension download fails (`cross-unzip` exit code 9 — Electron 4's chrome-web-store URLs are long dead), producing:

```
UnhandledPromiseRejectionWarning: Error: Exited with code 9
    at ChildProcess.<anonymous> (.../cross-unzip/index.js:38:21)
(node:...) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated.
In the future, promise rejections that are not handled will terminate the Node.js process
```

## Fix

Wrap the call in `Promise.resolve(installExtension(extension)).catch(...)` so the failure is logged via the existing `[ELECTRON] Extension installation failed` message instead of bubbling up as an unhandled rejection.

## Scope / risk

- Dev-only code path (`NODE_ENV === 'development'`), gated behind the existing block.
- The DevTools downloads still fail (expected on Electron 4.2.12 — separate, deeper issue), but the noise is gone.

## Verification

Launched `npm run dev` before/after on Node 14.21.3:
- **Before:** 3× `UnhandledPromiseRejectionWarning` + DEP0018 warning per launch.
- **After:** 0 unhandled rejections; failures logged cleanly; webpack bundle succeeds, Electron renderer launches normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)