### PR TITLE
fix(data): correct four note-index corruption bugs in data reducer

### DIFF
--- a/browser/main/dataReducer.js
+++ b/browser/main/dataReducer.js
@@ -92,7 +92,9 @@ export function data(state = defaultDataMap(), action) {
 
       if (oldNote != null) {
         updateTagChanges(oldNote, note, state, uniqueKey)
-      } else {
+      } else if (!note.isTrashed) {
+        // A brand-new note that is already trashed must stay out of the tag
+        // index, mirroring INIT_ALL's `if (!note.isTrashed)` guard.
         assignToTags(note.tags, state, uniqueKey)
       }
 
@@ -159,7 +161,9 @@ export function data(state = defaultDataMap(), action) {
         let noteSet = state.storageNoteMap.get(note.storage)
         noteSet = new Set(noteSet)
         noteSet.add(uniqueKey)
-        state.storageNoteMap.set(folderKey, noteSet)
+        // Index under the storage key, not the composite folder key, to match
+        // how storageNoteMap is keyed everywhere else (UPDATE_NOTE/INIT_ALL).
+        state.storageNoteMap.set(note.storage, noteSet)
       }
 
       // Update foldermap if folder changed or post created
@@ -317,12 +321,14 @@ export function data(state = defaultDataMap(), action) {
       state.storageMap = new Map(state.storageMap)
       state.storageMap.delete(action.storageKey)
 
-      // Remove folders from folderMap
+      // Remove folders from folderNoteMap. The state has no `folderMap` (only
+      // folderNoteMap), so the previous code mutated a phantom map and left
+      // the real folder index untouched.
       if (storage != null) {
-        state.folderMap = new Map(state.folderMap)
+        state.folderNoteMap = new Map(state.folderNoteMap)
         storage.folders.forEach(folder => {
           const folderKey = storage.key + '-' + folder.key
-          state.folderMap.delete(folderKey)
+          state.folderNoteMap.delete(folderKey)
         })
       }
 
@@ -346,6 +352,9 @@ export function data(state = defaultDataMap(), action) {
             let tagNoteSet = state.tagNoteMap.get(tag)
             tagNoteSet = new Set(tagNoteSet)
             tagNoteSet.delete(noteKey)
+            // Write the pruned set back; otherwise the deletion is discarded
+            // and the tag index keeps pointing at removed notes.
+            state.tagNoteMap.set(tag, tagNoteSet)
           })
         })
       }

--- a/tests/dataReducerActions.test.js
+++ b/tests/dataReducerActions.test.js
@@ -88,3 +88,49 @@ it('UPDATE_FOLDER replaces the storage entry', () => {
   })
   expect(state.storageMap.get('s1').name).toBe('Renamed')
 })
+
+it('MOVE_NOTE across storages indexes the new key under the destination storage', () => {
+  let state = initWith(
+    [{ key: 's1', folders: [{ key: 'f1' }] }],
+    [makeNote({ key: 'n1', storage: 's1', folder: 'f1' })]
+  )
+  // Moving across storages mints a new note key, so oldNote is null.
+  state = data(state, {
+    type: 'MOVE_NOTE',
+    originNote: makeNote({ key: 'n1', storage: 's1', folder: 'f1' }),
+    note: makeNote({ key: 'n2', storage: 's2', folder: 'f2' })
+  })
+  // The new key must land under the destination *storage* key, not the
+  // composite "storage-folder" key.
+  expect(state.storageNoteMap.get('s2').toJS()).toContain('n2')
+  expect(state.storageNoteMap.has('s2-f2')).toBe(false)
+})
+
+it('REMOVE_STORAGE purges the storage notes from the tag index', () => {
+  let state = initWith(
+    [{ key: 's1', folders: [{ key: 'f1' }] }],
+    [makeNote({ key: 'n1', tags: ['t1'] })]
+  )
+  state = data(state, { type: 'REMOVE_STORAGE', storageKey: 's1' })
+  // The note is gone, so it must not linger in the tag-to-note index.
+  expect(state.tagNoteMap.get('t1').toJS()).not.toContain('n1')
+})
+
+it('REMOVE_STORAGE purges the storage folders from the folder index', () => {
+  let state = initWith(
+    [{ key: 's1', folders: [{ key: 'f1' }] }],
+    [makeNote({ key: 'n1', folder: 'f1' })]
+  )
+  state = data(state, { type: 'REMOVE_STORAGE', storageKey: 's1' })
+  expect(state.folderNoteMap.has('s1-f1')).toBe(false)
+})
+
+it('UPDATE_NOTE does not index a brand-new trashed note into the tag map', () => {
+  const state = data(defaultDataMap(), {
+    type: 'UPDATE_NOTE',
+    note: makeNote({ key: 'n1', isTrashed: true, tags: ['t1'] })
+  })
+  // Trashed notes are excluded from tag search (INIT_ALL enforces the same).
+  const tagged = state.tagNoteMap.get('t1')
+  expect(tagged == null || !tagged.toJS().includes('n1')).toBe(true)
+})


### PR DESCRIPTION
## What

A targeted logic-bug sweep of `browser/main/dataReducer.js` surfaced four real index-corruption bugs (same class as the earlier ADD_STORAGE fix). Each is proven by a **new failing test that this PR turns green** (red→green; 4 tests added).

| # | Case | Bug | Fix |
|---|------|-----|-----|
| 1 | `MOVE_NOTE` (cross-storage) | new note key written to `storageNoteMap` under the composite `"storage-folder"` key instead of the storage key → destination storage's note set never gains the note, plus a bogus key is created | key by `note.storage` (matches UPDATE_NOTE / INIT_ALL) |
| 2 | `REMOVE_STORAGE` | tag set cloned + note deleted from it, but never written back to `tagNoteMap` → tag index keeps pointing at removed notes | add the missing `set()` |
| 3 | `REMOVE_STORAGE` | folder cleanup mutated a non-existent `folderMap` (state only has `folderNoteMap`) → folder index never pruned on storage removal | operate on `folderNoteMap` |
| 4 | `UPDATE_NOTE` | a brand-new, already-trashed note was assigned into the tag index | add `if (!note.isTrashed)` guard, mirroring INIT_ALL |

## Why they matter

These maps back folder/tag/storage filtering in the note list. The bugs leave stale or misplaced note keys in the indexes — manifesting as ghost notes in tag/folder views and an incomplete storage note set after a cross-storage move.

## Testing

- 4 new tests added to `tests/dataReducerActions.test.js`; confirmed each **fails before** the fix and **passes after**.
- Full suite green: **jest 223 passed**, **ava 14 passed** (`npm test` exit 0).
- `npm run lint` clean (pre-commit hook passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)