### PR TITLE
fix(data): coerce non-array tags in updateNote instead of throwing

### DIFF
--- a/browser/main/lib/dataApi/updateNote.js
+++ b/browser/main/lib/dataApi/updateNote.js
@@ -8,10 +8,13 @@ function validateInput(input) {
   const validatedInput = {}
 
   if (input.tags != null) {
+    // Guard against non-array tags: calling .filter() on a string/object
+    // throws. Coerce to [] instead, matching the title/content handling below.
     if (!_.isArray(input.tags)) validatedInput.tags = []
-    validatedInput.tags = input.tags.filter(
-      tag => _.isString(tag) && tag.trim().length > 0
-    )
+    else
+      validatedInput.tags = input.tags.filter(
+        tag => _.isString(tag) && tag.trim().length > 0
+      )
   }
 
   if (input.title != null) {

--- a/tests/dataApi/updateNote-test.js
+++ b/tests/dataApi/updateNote-test.js
@@ -140,6 +140,37 @@ test.serial('Update a note', t => {
     })
 })
 
+test.serial(
+  'Update a note with non-array tags sanitises to an empty array',
+  t => {
+    const storageKey = t.context.storage.cache.key
+    const folderKey = t.context.storage.json.folders[0].key
+
+    const input = {
+      type: 'MARKDOWN_NOTE',
+      content: faker.lorem.lines(),
+      tags: ['real'],
+      folder: folderKey
+    }
+    input.title = input.content.split('\n').shift()
+
+    return createNote(storageKey, input)
+      .then(function update(note) {
+        // `tags` is not an array — validateInput must coerce it to [] rather
+        // than calling .filter() on a non-array and throwing a TypeError that
+        // rejects the whole update.
+        return updateNote(note.storage, note.key, {
+          type: 'MARKDOWN_NOTE',
+          content: faker.lorem.lines(),
+          tags: 'not-an-array'
+        })
+      })
+      .then(function assert(updated) {
+        t.deepEqual(updated.tags, [])
+      })
+  }
+)
+
 test.after(function after() {
   localStorage.clear()
   sander.rimrafSync(storagePath)


### PR DESCRIPTION
## What

In `browser/main/lib/dataApi/updateNote.js`, `validateInput()` had:

```js
if (input.tags != null) {
  if (!_.isArray(input.tags)) validatedInput.tags = []
  validatedInput.tags = input.tags.filter(...)   // runs even when not an array
}
```

The guard set `[]` but the very next line **unconditionally** called `.filter()` on `input.tags`. When `tags` is not an array (string/object/number), `.filter` is not a function → `TypeError: input.tags.filter is not a function`, which rejects the entire update.

## Fix

Add the missing `else`, so a non-array `tags` coerces to `[]` — exactly how `title` and `content` are already validated in the same function.

## Testing

- New ava test `Update a note with non-array tags sanitises to an empty array` — confirmed **red before** (`TypeError: input.tags.filter is not a function`), **green after**.
- Full suite: **ava 15 passed, jest 223 passed** (`npm test` exit 0).
- `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)