### PR TITLE
fix(data): settle snippet-API promises correctly

### DIFF
--- a/browser/main/lib/dataApi/fetchSnippet.js
+++ b/browser/main/lib/dataApi/fetchSnippet.js
@@ -5,7 +5,10 @@ function fetchSnippet(id, snippetFile) {
   return new Promise((resolve, reject) => {
     fs.readFile(snippetFile || consts.SNIPPET_FILE, 'utf8', (err, data) => {
       if (err) {
+        // Return early; otherwise JSON.parse(undefined) throws inside this
+        // callback after the promise has already been rejected.
         reject(err)
+        return
       }
       const snippets = JSON.parse(data)
       if (id) {
@@ -13,8 +16,9 @@ function fetchSnippet(id, snippetFile) {
           return snippet.id === id
         })
         resolve(snippet)
+      } else {
+        resolve(snippets)
       }
-      resolve(snippets)
     })
   })
 }

--- a/browser/main/lib/dataApi/updateSnippet.js
+++ b/browser/main/lib/dataApi/updateSnippet.js
@@ -7,10 +7,12 @@ function updateSnippet(snippet, snippetFile) {
       fs.readFileSync(snippetFile || consts.SNIPPET_FILE, 'utf-8')
     )
 
+    let found = false
     for (let i = 0; i < snippets.length; i++) {
       const currentSnippet = snippets[i]
 
       if (currentSnippet.id === snippet.id) {
+        found = true
         if (
           currentSnippet.name === snippet.name &&
           currentSnippet.prefix === snippet.prefix &&
@@ -33,8 +35,12 @@ function updateSnippet(snippet, snippetFile) {
             }
           )
         }
+        break
       }
     }
+
+    // No snippet matched: settle the promise so callers don't hang forever.
+    if (!found) resolve(snippets)
   })
 }
 

--- a/tests/dataApi/fetchSnippet-test.js
+++ b/tests/dataApi/fetchSnippet-test.js
@@ -1,0 +1,50 @@
+const test = require('ava')
+const fetchSnippet = require('browser/main/lib/dataApi/fetchSnippet')
+const sander = require('sander')
+const os = require('os')
+const path = require('path')
+const crypto = require('crypto')
+
+const snippetFilePath = path.join(os.tmpdir(), 'test', 'fetch-snippet')
+const snippetFile = path.join(snippetFilePath, 'snippets.json')
+const snippetA = {
+  id: crypto.randomBytes(16).toString('hex'),
+  name: 'A',
+  prefix: [],
+  content: 'a'
+}
+const snippetB = {
+  id: crypto.randomBytes(16).toString('hex'),
+  name: 'B',
+  prefix: [],
+  content: 'b'
+}
+
+test.beforeEach(t => {
+  sander.writeFileSync(snippetFile, JSON.stringify([snippetA, snippetB]))
+})
+
+test.serial('Fetching without an id returns every snippet', t => {
+  return fetchSnippet(null, snippetFile).then(snippets => {
+    t.true(Array.isArray(snippets))
+    t.is(snippets.length, 2)
+  })
+})
+
+test.serial('Fetching with an id returns the matching snippet', t => {
+  return fetchSnippet(snippetB.id, snippetFile).then(snippet => {
+    t.is(snippet.id, snippetB.id)
+    t.is(snippet.name, 'B')
+  })
+})
+
+test.serial('Fetching from a missing file rejects cleanly', t => {
+  // Before the fix, the error branch lacked a return, so it fell through to
+  // JSON.parse(undefined) and threw inside the fs callback after rejecting.
+  const missingFile = path.join(snippetFilePath, 'does-not-exist.json')
+  return t.throws(fetchSnippet(null, missingFile))
+})
+
+test.after.always(() => {
+  sander.rimrafSync(snippetFilePath)
+})

--- a/tests/dataApi/updateSnippet-test.js
+++ b/tests/dataApi/updateSnippet-test.js
@@ -42,6 +42,24 @@ test.serial('Update a snippet', t => {
     })
 })
 
+test.serial(
+  'Updating a non-existent snippet resolves instead of hanging',
+  t => {
+    const missing = {
+      id: crypto.randomBytes(16).toString('hex'),
+      name: 'ghost',
+      prefix: [],
+      content: ''
+    }
+    // Before the fix the promise never settled when no snippet matched, so any
+    // caller awaiting it hung forever. It must resolve with the snippet list.
+    return updateSnippet(missing, snippetFile).then(snippets => {
+      t.true(Array.isArray(snippets))
+      t.is(snippets.length, 1)
+    })
+  }
+)
+
 test.after.always(() => {
   sander.rimrafSync(snippetFilePath)
 })


### PR DESCRIPTION
## What

Two promise-settling bugs in the snippet data API.

### `updateSnippet.js` — hang on no match (red→green)
The promise only called `resolve`/`reject` *inside* the `if (currentSnippet.id === snippet.id)` branch. Updating a snippet whose id isn't in the file fell through the loop without settling, so any caller awaiting it **hung forever**. Fixed by tracking a `found` flag, `break`ing on match, and `resolve(snippets)` after the loop when nothing matched.

### `fetchSnippet.js` — fall-through + double resolve
```js
if (err) { reject(err) }        // no return → falls through
const snippets = JSON.parse(data)  // data is undefined on error → throws in callback
if (id) { ... resolve(snippet) }
resolve(snippets)               // runs unconditionally → second resolve
```
On a read error, after `reject(err)` the callback continued to `JSON.parse(undefined)` and threw an **uncaught exception**; and when `id` was given the promise resolved twice. Fixed with an early `return` after `reject` and an `else` for the no-id branch.

## Testing

- New ava test `Updating a non-existent snippet resolves instead of hanging` — confirmed **red** (hangs/times out) before the `updateSnippet` fix, **green** after.
- New `tests/dataApi/fetchSnippet-test.js`: fetch-all, fetch-by-id, and missing-file-rejection regression guards.
- Full suite: **jest 223, ava 19** (`npm test` exit 0); `npm run lint` clean.

Note: AVA here is 0.25, so tests use `t.throws(promise)` (no `t.throwsAsync`/`t.timeout`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)