### PR TITLE
fix(data): apply discarded snippet filter in updateNote validation

### DIFF
--- a/browser/main/lib/dataApi/updateNote.js
+++ b/browser/main/lib/dataApi/updateNote.js
@@ -67,7 +67,9 @@ function validateInput(input) {
         } else {
           validatedInput.snippets = input.snippets
         }
-        validatedInput.snippets.filter(snippet => {
+        // Assign the filtered result back; otherwise invalid snippets pass
+        // through and get written to disk.
+        validatedInput.snippets = validatedInput.snippets.filter(snippet => {
           if (!_.isString(snippet.name)) return false
           if (!_.isString(snippet.mode)) return false
           if (!_.isString(snippet.content)) return false

--- a/tests/dataApi/updateNote-test.js
+++ b/tests/dataApi/updateNote-test.js
@@ -171,6 +171,43 @@ test.serial(
   }
 )
 
+test.serial(
+  'Update a snippet note drops snippets with non-string fields',
+  t => {
+    const storageKey = t.context.storage.cache.key
+    const folderKey = t.context.storage.json.folders[0].key
+
+    const createInput = {
+      type: 'SNIPPET_NOTE',
+      description: faker.lorem.lines(),
+      snippets: [
+        { name: 'valid', mode: 'text', content: 'ok', linesHighlighted: [] }
+      ],
+      tags: [],
+      folder: folderKey
+    }
+    createInput.title = createInput.description.split('\n').shift()
+
+    return createNote(storageKey, createInput)
+      .then(function update(note) {
+        // The second snippet has a non-string name; validateInput must filter it
+        // out instead of discarding the filter result and persisting it.
+        return updateNote(note.storage, note.key, {
+          type: 'SNIPPET_NOTE',
+          description: faker.lorem.lines(),
+          snippets: [
+            { name: 'keep', mode: 'text', content: 'ok', linesHighlighted: [] },
+            { name: 123, mode: 'text', content: 'bad', linesHighlighted: [] }
+          ]
+        })
+      })
+      .then(function assert(updated) {
+        t.is(updated.snippets.length, 1)
+        t.is(updated.snippets[0].name, 'keep')
+      })
+  }
+)
+
 test.after(function after() {
   localStorage.clear()
   sander.rimrafSync(storagePath)


### PR DESCRIPTION
## What

In `updateNote.js` `validateInput()`, the `SNIPPET_NOTE` branch computed a filtered snippet array but **threw the result away**:

```js
validatedInput.snippets.filter(snippet => {
  if (!_.isString(snippet.name)) return false
  if (!_.isString(snippet.mode)) return false
  if (!_.isString(snippet.content)) return false
  return true
})   // result not assigned
```

So snippets with non-string `name`/`mode`/`content` passed validation and were written to disk. Fixed by assigning the result back to `validatedInput.snippets`.

## Testing

- New ava test `Update a snippet note drops snippets with non-string fields` — **red before** (a snippet with a numeric name persisted → length 2), **green after** (length 1, only the valid snippet).
- Full suite: **ava 20, jest 223** (`npm test` exit 0); `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)