### PR TITLE
fix(attachment): stop corrupting pasted images via doubled base64

### DIFF
--- a/browser/main/lib/dataApi/attachmentManagement.js
+++ b/browser/main/lib/dataApi/attachmentManagement.js
@@ -492,7 +492,6 @@ function handlePasteImageEvent(
 
   reader.onloadend = function() {
     base64data = reader.result.replace(/^data:image\/png;base64,/, '')
-    base64data += base64data.replace('+', ' ')
     const binaryData = Buffer.from(base64data, 'base64').toString('binary')
     fs.writeFileSync(imagePath, binaryData, 'binary')
     const imageReferencePath = path.join(

--- a/tests/dataApi/attachmentManagement.test.js
+++ b/tests/dataApi/attachmentManagement.test.js
@@ -2007,3 +2007,45 @@ it('should test that handleAttachmentLinkPaste returns the correct modified past
       expect(returnedPastedText).toBe(expectedPastText)
     })
 })
+
+it('should test that handlePasteImageEvent writes the pasted image without corrupting the base64 data', done => {
+  findStorage.findStorage = jest.fn(() => ({ path: 'dummyStoragePath' }))
+  uniqueSlug.mockReturnValue('pastedimage')
+  fs.writeFileSync = jest.fn()
+
+  // 9 bytes: divisible by 3 so the base64 has no '=' padding. Without padding,
+  // the old `base64data += ...` doubling is not hidden by Node's decoder
+  // stopping at '=', so the corruption (≈double the bytes) becomes observable.
+  const pngBytes = Buffer.from([
+    0x89,
+    0x50,
+    0x4e,
+    0x47,
+    0x0d,
+    0x0a,
+    0x1a,
+    0x0a,
+    0xfb
+  ])
+  const blob = new Blob([pngBytes], { type: 'image/png' })
+  const dataTransferItem = { getAsFile: () => blob }
+
+  const codeEditor = {
+    insertAttachmentMd: () => {
+      // onloadend has run and the file has been written by now.
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(1)
+      const writtenBinary = fs.writeFileSync.mock.calls[0][1]
+      // The bytes written must decode back to exactly the original image; the
+      // old `base64data += base64data.replace('+', ' ')` doubled/garbled them.
+      expect(Buffer.from(writtenBinary, 'binary').equals(pngBytes)).toBe(true)
+      done()
+    }
+  }
+
+  systemUnderTest.handlePasteImageEvent(
+    codeEditor,
+    'storageKey',
+    'noteKey',
+    dataTransferItem
+  )
+})


### PR DESCRIPTION
## What

`handlePasteImageEvent` (paste an image into the editor) did:

```js
base64data = reader.result.replace(/^data:image\/png;base64,/, '')
base64data += base64data.replace('+', ' ')   // <-- appends a second, mangled copy
const binaryData = Buffer.from(base64data, 'base64').toString('binary')
```

The `+=` appends a second copy of the base64 (with the first `+` turned into a space) to itself, then decodes the doubled string and writes it as the image file.

## Why it sometimes "worked"

When the image's byte length is **not** divisible by 3, the base64 ends with `=` padding and Node's decoder stops there — so the appended copy is ignored and the image is fine. When the length **is** divisible by 3 there is no padding, Node decodes the whole doubled string, and the written file gets ≈twice the bytes → a corrupted image. That data-dependence is why this 2018 bug stayed hidden.

## Fix

Remove the bogus line. `reader.result` from `readAsDataURL` is already standard base64; no transformation is needed.

## Testing

- New jest test pastes a **9-byte (unpadded)** image and asserts the written bytes decode back to exactly the original. Confirmed **red before** (fails — corrupted/doubled), **green after**.
- Full suite: **jest 224, ava 20** (`npm test` exit 0); `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)