### PR TITLE
fix: pin flowchart.js to 1.10.0 to fix infinite loading on startup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6567,11 +6567,21 @@
       }
     },
     "flowchart.js": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/flowchart.js/-/flowchart.js-1.18.0.tgz",
-      "integrity": "sha512-1rZflSLyrj5/+ryzU+qIQr6IGysPIHT4UrgN+6IaVv7pLDSLu7CvC9e0X7FU6ocpRAEtHk5+UaFXv9NZKRoG3g==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/flowchart.js/-/flowchart.js-1.10.0.tgz",
+      "integrity": "sha512-NMmgNvWZ9IMG0nIZzG1K9tP1SpXTsI6uoTpLh29F3UwB/qlpOKZW/EfpOuXHqGdgvbkJKWhnwiGShzVWAYj7Ew==",
       "requires": {
-        "raphael": "2.3.0"
+        "raphael": "2.2.7"
+      },
+      "dependencies": {
+        "raphael": {
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.2.7.tgz",
+          "integrity": "sha512-3Mf8DDgWZpvEp4aXbMyCxLZERHLd9OIfVo0sFIi5NmcTHt4nQXVrMX1C759vMoPSEmI8XhKrbWNYpLlQADs/GQ==",
+          "requires": {
+            "eve-raphael": "0.5.0"
+          }
+        }
       }
     },
     "fn-name": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "file-uri-to-path": "^1.0.0",
     "file-url": "^2.0.2",
     "filenamify": "^2.1.0",
-    "flowchart.js": "^1.6.5",
+    "flowchart.js": "1.10.0",
     "font-awesome": "^4.3.0",
     "fs-extra": "^5.0.0",
     "grunt-cli": "^1.5.0",


### PR DESCRIPTION
## 症状
起動時にローディング画面が消えず固まる（無限ローディング）。レンダラで `Uncaught ReferenceError: flowchart is not defined` が初回描画中に発生し、`#loadingCover` を除去する `ReactDOM.render` のコールバックが走らない。

## 根本原因
`flowchart` は webpack の **external**（`webpack-skeleton.js`: `flowchart: 'var flowchart'`）。つまりバンドルせず、HTML の `<script>` で読み込むグローバル前提：
```
lib/main.{development,production}.html
  <script src="../node_modules/flowchart.js/release/flowchart.min.js"></script>
```
ところが依存範囲 `"^1.6.5"` が **`flowchart.js@1.18.0`** を解決していた。1.18.0 は `release/flowchart.min.js` を同梱しない（jQuery 依存のソースのみ構成に再編）。`<script>` が 404 → グローバル `flowchart` 未定義 → `MarkdownPreview` の `import flowchart from 'flowchart'`（external）が初回描画で例外 → 無限ローディング。

`raphael` は `raphael.min.js` が実在するため正常 → エラーが `flowchart` だけだったのと符合。

## 修正
`flowchart.js` を **1.10.0** に固定。`release/flowchart.min.js`（`window.flowchart` を定義する Raphael ベースの自己完結版）を同梱する最終ライン。HTML / webpack は無変更で既存の script パスが再び解決する。

| 版 | `release/flowchart.min.js` | 依存 |
|---|---|---|
| 1.6.5 / 1.10.0 | ✅ | raphael 2.2.7 |
| 1.15.0+ / 1.18.0 | ❌ | raphael 2.3.0（jQuery系へ再編） |

## 検証
`ELECTRON_ENABLE_LOGGING=1` で再起動し、レンダラのコンソールを確認：
- 修正前: `Uncaught ReferenceError: flowchart is not defined`
- 修正後: 同エラー **0件** / Uncaught・TypeError・ReferenceError **0件**、renderer 起動、初回描画完了で `#loadingCover` 除去
- フルテスト緑（jest 224 / ava 20）、`npm run lint` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)