### PR TITLE
fix(detail): correct event-listener cleanup in MarkdownNoteDetail

### DIFF
--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -62,6 +62,17 @@ class MarkdownNoteDetail extends React.Component {
     this.handleUpdateContent = this.handleUpdateContent.bind(this)
     this.handleSwitchStackDirection = this.handleSwitchStackDirection.bind(this)
     this.getNote = this.getNote.bind(this)
+    // Stable listener refs so componentWillUnmount can remove every listener.
+    // Previously these were registered as inline/anonymous handlers that could
+    // never be removed, leaking a listener on every note switch (and making the
+    // toggle handlers fire multiple times).
+    this.handleSwitchDirection = this.handleSwitchDirection.bind(this)
+    this.handleDeleteNote = this.handleDeleteNote.bind(this)
+    this.handleToggleMode = () => {
+      const reversedType =
+        this.state.editorType === 'SPLIT' ? 'EDITOR_PREVIEW' : 'SPLIT'
+      this.handleSwitchMode(reversedType)
+    }
   }
 
   focus() {
@@ -71,13 +82,9 @@ class MarkdownNoteDetail extends React.Component {
   componentDidMount() {
     ee.on('editor:orientation', this.handleSwitchStackDirection)
     ee.on('topbar:togglelockbutton', this.toggleLockButton)
-    ee.on('topbar:toggledirectionbutton', () => this.handleSwitchDirection())
-    ee.on('topbar:togglemodebutton', () => {
-      const reversedType =
-        this.state.editorType === 'SPLIT' ? 'EDITOR_PREVIEW' : 'SPLIT'
-      this.handleSwitchMode(reversedType)
-    })
-    ee.on('hotkey:deletenote', this.handleDeleteNote.bind(this))
+    ee.on('topbar:toggledirectionbutton', this.handleSwitchDirection)
+    ee.on('topbar:togglemodebutton', this.handleToggleMode)
+    ee.on('hotkey:deletenote', this.handleDeleteNote)
     ee.on('code:generate-toc', this.generateToc)
   }
 
@@ -114,8 +121,11 @@ class MarkdownNoteDetail extends React.Component {
   }
 
   componentWillUnmount() {
+    ee.off('editor:orientation', this.handleSwitchStackDirection)
     ee.off('topbar:togglelockbutton', this.toggleLockButton)
-    ee.on('topbar:toggledirectionbutton', this.handleSwitchDirection)
+    ee.off('topbar:toggledirectionbutton', this.handleSwitchDirection)
+    ee.off('topbar:togglemodebutton', this.handleToggleMode)
+    ee.off('hotkey:deletenote', this.handleDeleteNote)
     ee.off('code:generate-toc', this.generateToc)
     if (this.saveQueue != null) this.saveNow()
   }


### PR DESCRIPTION
## What

`MarkdownNoteDetail` mishandled its eventEmitter listeners:

- **`componentWillUnmount` had `ee.on('topbar:toggledirectionbutton', ...)` instead of `ee.off`** — it *registered* a listener on every unmount.
- Several listeners added in `componentDidMount` used inline/anonymous/`.bind(this)` callbacks (`editor:orientation`, `topbar:toggledirectionbutton`, `topbar:togglemodebutton`, `hotkey:deletenote`) and were **never removed**.

Net effect: switching between notes leaked listeners, and the topbar toggles (direction / mode / lock) would fire multiple times after a few note switches.

## Fix

Bind stable handler refs in the constructor, register them in `componentDidMount`, and `ee.off` all six in `componentWillUnmount`. Handler behavior is unchanged — only registration/removal references were corrected.

`SnippetNoteDetail` registers a single listener and already removes it correctly → left as-is.

## Verification

- Full suite green: **jest 224, ava 20**; `npm run lint` clean.
- Launched the app (`ELECTRON_ENABLE_LOGGING=1`): it loads and renders a note view (renderer up), no app-code errors. (An unrelated `queueMicrotask is not defined` originates from a YouTube embed iframe under Electron 4's old Chromium — not from app code.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)