### PR TITLE
fix(renderer): leaked NoteList listener + silent note-save failures

### DIFF
--- a/browser/main/Detail/MarkdownNoteDetail.js
+++ b/browser/main/Detail/MarkdownNoteDetail.js
@@ -171,13 +171,18 @@ class MarkdownNoteDetail extends React.Component {
     clearTimeout(this.saveQueue)
     this.saveQueue = null
 
-    dataApi.updateNote(note.storage, note.key, this.state.note).then(note => {
-      dispatch({
-        type: 'UPDATE_NOTE',
-        note: note
+    dataApi
+      .updateNote(note.storage, note.key, this.state.note)
+      .then(note => {
+        dispatch({
+          type: 'UPDATE_NOTE',
+          note: note
+        })
+        AwsMobileAnalyticsConfig.recordDynamicCustomEvent('EDIT_NOTE')
       })
-      AwsMobileAnalyticsConfig.recordDynamicCustomEvent('EDIT_NOTE')
-    })
+      .catch(err => {
+        console.error('Cannot save note: ' + err)
+      })
   }
 
   handleFolderChange(e) {

--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -145,6 +145,7 @@ class NoteList extends React.Component {
     ee.off('list:isMarkdownNote', this.alertIfSnippetHandler)
     ee.off('import:file', this.importFromFileHandler)
     ee.off('list:jump', this.jumpNoteByHash)
+    ee.off('list:navigate', this.navigate)
   }
 
   componentDidUpdate(prevProps) {

--- a/browser/main/SideNav/index.js
+++ b/browser/main/SideNav/index.js
@@ -94,28 +94,32 @@ class SideNav extends React.Component {
 
       Promise.all(
         notes.map(note => dataApi.updateNote(note.storage, note.key, note))
-      ).then(updatedNotes => {
-        updatedNotes.forEach(note => {
-          dispatch({
-            type: 'UPDATE_NOTE',
-            note
+      )
+        .then(updatedNotes => {
+          updatedNotes.forEach(note => {
+            dispatch({
+              type: 'UPDATE_NOTE',
+              note
+            })
           })
-        })
 
-        if (location.pathname.match('/tags')) {
-          const tags = params.tagname.split(' ')
-          const index = tags.indexOf(tag)
-          if (index !== -1) {
-            tags.splice(index, 1)
+          if (location.pathname.match('/tags')) {
+            const tags = params.tagname.split(' ')
+            const index = tags.indexOf(tag)
+            if (index !== -1) {
+              tags.splice(index, 1)
 
-            dispatch(
-              push(
-                `/tags/${tags.map(tag => encodeURIComponent(tag)).join(' ')}`
+              dispatch(
+                push(
+                  `/tags/${tags.map(tag => encodeURIComponent(tag)).join(' ')}`
+                )
               )
-            )
+            }
           }
-        }
-      })
+        })
+        .catch(err => {
+          console.error('Cannot update notes after removing tag: ' + err)
+        })
     }
   }
 


### PR DESCRIPTION
コンポーネント層スイープで見つかった信頼性バグ3件。

- **NoteList**: `list:navigate` を `componentDidMount` で登録するが `componentWillUnmount` で解除していない（他7個は解除済み）。`ee.off('list:navigate', this.navigate)` を追加し、mount の度に増殖するのを修正。
- **MarkdownNoteDetail.saveNow**: `dataApi.updateNote(...).then(...)` に `.catch` が無く、保存失敗がサイレントな unhandled rejection に。既存の `console.error` 慣習に合わせて `.catch` を追加。
- **SideNav（タグ削除ハンドラ）**: `Promise.all(updateNote...)` も同様に `.catch` 欠落（兄弟の削除ハンドラには有る）。追加。

成功時の挙動は不変。失敗が握り潰されず表面化し、リスナーも蓄積しなくなる。フルテスト緑（jest 224 / ava 20）、実機で起動・描画確認（renderer 稼働・app-code エラー0）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)