### PR TITLE
poc: validated collab-core (Yjs + CodeMirror 6 + self-hosted Hocuspocus + .cson)

### DIFF
--- a/.claude/skills/boostnote-modernize/SKILL.md
+++ b/.claude/skills/boostnote-modernize/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: boostnote-modernize
+description: Architecture, decisions, and working rules for modernizing Boostnote into a modern, collaborative, extensible note app. Load this before working on the modernization (stack choices, the collab core, the dependency overhaul, deploy/ops, or the new-app shell). Benchmarks: Obsidian, HackMD.
+---
+
+# Boostnote Modernization — architect skill
+
+Single source of truth for the rebuild. The legacy app is the discontinued
+Boostnote (Electron 4 + React 16 + Redux + CodeMirror 5 + webpack 1, notes as
+on-disk `.cson`). Goal: a **modern, high-performance, extensible** note app that
+**inherits the existing UI/UX** as a baseline while exploring new concepts,
+benchmarked against **Obsidian** (local-first, plugin ecosystem) and **HackMD**
+(real-time collaborative markdown).
+
+License: **GPL-3.0** (inherited from BoostIO). Any rebuild stays GPL-3.0.
+
+## Locked architecture decisions (do not re-litigate)
+
+| Layer | Decision | Why |
+|---|---|---|
+| Desktop shell | **Electron**, modernized to the latest supported major (v42 line) | reuse React UI + Node `.cson` I/O; mature mac+win signing/notarization/auto-update. Tauri 2 only as a later, optional footprint pass |
+| Build | **Vite / electron-vite** (replacing webpack 1) | webpack 1 is unevolvable |
+| UI framework | **React → 19** + Redux Toolkit (incremental) | maximal reuse of existing React assets |
+| Editor core | **CodeMirror 6 + y-codemirror.next** (source markdown) | markdown string IS the CRDT payload (1:1 with `.cson`); preview pipeline (markdown-it/KaTeX/mermaid) reused. WYSIWYG (TipTap/Lexical/Milkdown) makes markdown lossy |
+| Collab data model | **Yjs CRDT** — 1 note = `Y.Doc` (`content`→`Y.Text`, metadata→`Y.Map`, snippets→`Y.Array`) | character-level merge, local-first + real-time in one lib |
+| Persistence | Yjs doc = source of truth; **`.cson` = derived snapshot** (write-back); `y-indexeddb` for local-first | keeps on-disk files + search + git interop |
+| Sync backend | **self-hosted Hocuspocus** (fallback: y-sweet) | flat VPS cost, plaintext stays on our box, minimal lock-in |
+| Auth | **device-pairing** (single-user, multiple devices) — NOT a multi-user auth provider | user confirmed: collaboration is across their own devices only. Yjs has no ACL, so the socket MUST still be gated (`onAuthenticate`) |
+| Encryption | E2E NOT required (provider trust accepted); Yjs leaves an E2E escape hatch for later | user prioritized real-time over E2E |
+
+Effort estimate (solo + AI): **~16–24 weeks**, phased, each phase shippable.
+The CodeMirror 5→6 port is the only essential spike.
+
+## What is already validated / done
+
+- **`poc/collab-core/`** — runnable PoC proving the hardest part. `npm test`
+  (Node 22) shows: device-pairing auth rejects bad tokens, A→B convergence,
+  concurrent edits both survive, `.cson` snapshot write-back, late device
+  re-seeded from snapshot. Browser client = HackMD-style split editor (CM6 +
+  collaborative cursors + markdown-it/DOMPurify preview). **This is the editor
+  pane prototype for the new app.**
+- **`docs/MODERNIZATION-2026-stack-selection.md`** + **`-collab-revision.md`** —
+  fact-checked design judgment (stars/license/versions/pricing verified;
+  threat model; decision matrices; roadmap; locked decisions section).
+
+## Working rules
+
+- **PRs go ONLY to `BoxPistols/Boostnote`** (never upstream BoostIO). Verify
+  `isCrossRepository:false`. See the `pr-fork-only` memory.
+- **Legacy app** runs on Node 14 via `~/.volta/bin/volta run --node 14.21.3 …`;
+  do NOT `cd` into the repo in Bash (a chpwd hook spams `ls`). Tests: `npm test`
+  (ava + jest); always `npm run lint` then `npm run fix` before commit. Diagnose
+  renderer issues with `ELECTRON_ENABLE_LOGGING=1 npm run dev`.
+- **Modern code** (`poc/`, future `app/`) uses Node 22:
+  `~/.volta/bin/volta run --node 22.22.3 …`. Keep it isolated from the legacy
+  build — `poc/` is in `.eslintignore`; new modern workspaces likewise.
+- **Old/broken packages:** the legacy app loads several libs as global
+  `<script>` tags / webpack externals in `lib/main.{development,production}.html`.
+  Dependency bumps silently break those paths → infinite loading. Two have been
+  fixed (flowchart.js → pin 1.10.0, #51; codemirror-mode-elixir → correct umd
+  path, #56). Re-verify every `<script src="../node_modules/…">` resolves after
+  any dep change. See the `flowchart-infinite-loading` memory.
+- **Every modernization artifact (PoC / app / server) gets a README covering
+  run + build + deploy/distribution + operations** (per the user's directive).
+- Document new architecture decisions back into `docs/` and update this skill.
+
+## New-app concept (benchmark Obsidian + HackMD)
+
+Baseline = the current 3-pane UX (sidebar: All Notes / Starred / Trash + storages
+/ folders / tags; note list with sort; split CM6 editor + live preview; dark
+theme with the pink accent). Differentiators to explore: real-time collab across
+your devices (HackMD), local-first files + extensibility/plugins + linking
+(Obsidian). **The degree of departure from the familiar UX is a product decision
+to confirm with the user before building the app shell.**
+
+## Deploy / distribution / operations (target)
+
+- **App distribution:** Electron auto-update (electron-updater) with signed +
+  notarized mac (dmg/zip) and Windows (nsis) artifacts, built in CI.
+- **Sync server:** Hocuspocus as a small Node service on a single VPS (or a
+  container). TLS via a reverse proxy (Caddy/Traefik). Persist the Yjs update
+  log (SQLite/Postgres) in addition to the `.cson` snapshot; nightly backups of
+  both the DB and the snapshot dir. One always-on process; restart via systemd.
+- **Cost shape:** flat ~$5–12/mo VPS, no per-user fees (single-user, few rooms).
+- **Ops runbook lives in each component's README** and is kept current.

--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ compiled/
 dist/
 extra_scripts/
 coverage/
+poc/

--- a/poc/collab-core/.gitignore
+++ b/poc/collab-core/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+client/dist/
+snapshots/
+*.log

--- a/poc/collab-core/README.md
+++ b/poc/collab-core/README.md
@@ -1,0 +1,52 @@
+# collab-core PoC
+
+Proves the hardest part of the Boostnote modernization architecture: **real-time
+collaborative markdown editing that stays local-first and keeps "the file is the
+source of truth"**, with a **self-hosted** sync server and **device-pairing** auth.
+
+This is a standalone modern-Node (22) project. It is **not** part of the legacy
+Electron app build (the legacy lint/CI ignore `poc/`).
+
+## What it validates
+
+| Concern | How |
+|---|---|
+| Character-level concurrent editing (no lost writes) | Yjs CRDT (`Y.Text` per note) |
+| Local-first / offline | Yjs (+ `y-indexeddb` in the browser) |
+| "File is the source of truth" | server writes a derived `.cson` snapshot in the **legacy note shape** on every change, and seeds a freshly-loaded doc back from it |
+| Self-hosted, flat-cost sync | Hocuspocus (`@hocuspocus/server`) |
+| Access control (Yjs has none) | device-pairing token verified in `onAuthenticate` |
+| Editor | CodeMirror 6 + `y-codemirror.next` (`yCollab`) — same pipeline as the legacy app (source markdown + markdown-it preview) |
+
+## Layout
+
+- `server/hocuspocus-server.mjs` — sync server: `onAuthenticate` (pairing gate),
+  `onLoadDocument` (seed from `.cson`), `onStoreDocument` (write `.cson` snapshot).
+- `test/convergence.test.mjs` — **headless proof**: two Yjs clients, auth
+  rejection, A→B convergence, concurrent-edit survival, `.cson` write-back, and a
+  late device re-seeded from the snapshot.
+- `client/` — HackMD-style split editor (CM6 left, live markdown-it+DOMPurify
+  preview right) with collaborative cursors. Prototype of the modern app's editor pane.
+
+## Run
+
+```bash
+# Node 22 (the repo pins Node 14 for the legacy app; this needs modern Node)
+npm install
+
+# 1) headless proof — no browser needed
+npm test
+#    -> "All 6 checks passed — collab core architecture validated."
+
+# 2) live demo
+npm run server          # terminal A: Hocuspocus on ws://127.0.0.1:1234
+npm run dev             # terminal B: Vite; open the URL in TWO windows and type
+```
+
+## Notes / next
+
+- The PoC persists only a `.cson` **snapshot**; production should also persist the
+  Yjs update log (e.g. Hocuspocus `Database`/SQLite) so history/undo survive restarts.
+- Auth here is a single shared token; the real app uses per-device pairing
+  (single-user, multi-device — no multi-user auth provider needed).
+- License: inherits the repository's **GPL-3.0**.

--- a/poc/collab-core/README.md
+++ b/poc/collab-core/README.md
@@ -43,6 +43,27 @@ npm run server          # terminal A: Hocuspocus on ws://127.0.0.1:1234
 npm run dev             # terminal B: Vite; open the URL in TWO windows and type
 ```
 
+## Deploy / distribution / operations
+
+This PoC's server is the seed of the production sync service.
+
+- **Sync server (Hocuspocus):** one always-on Node service on a small VPS (or
+  container), behind a TLS reverse proxy (Caddy/Traefik), managed by `systemd`
+  (auto-restart). One process suffices for single-user / few-room use.
+- **Persistence:** this PoC writes only a `.cson` snapshot. Production must also
+  persist the **Yjs update log** (Hocuspocus `Database` extension → SQLite/
+  Postgres) so undo/history survive restarts. Back up **both** the DB and the
+  `snapshots/` dir nightly; keep snapshots in the user's notes folder so they
+  stay git/Dropbox/iCloud-friendly.
+- **Auth:** replace the demo token with a **per-device pairing token** (issued at
+  pairing, verified in `onAuthenticate`); never ship a hardcoded secret. Store it
+  in Electron `safeStorage` (main process), not renderer `localStorage`.
+- **App distribution:** Electron auto-update (`electron-updater`) with **signed +
+  notarized** macOS (dmg/zip) and Windows (nsis) artifacts built in CI.
+- **Cost shape:** flat ~$5–12/mo VPS, no per-user/per-connection fees.
+- **Resilience:** the desktop app keeps working offline via `y-indexeddb`, so a
+  server outage degrades to local-only — not data loss.
+
 ## Notes / next
 
 - The PoC persists only a `.cson` **snapshot**; production should also persist the

--- a/poc/collab-core/client/index.html
+++ b/poc/collab-core/client/index.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Boostnote collab PoC — split editor</title>
+    <style>
+      :root {
+        --bg: #1e2126;
+        --bg2: #21252b;
+        --fg: #d7dae0;
+        --muted: #7f8694;
+        --accent: #ff2d75;
+        --border: #2c313a;
+      }
+      * { box-sizing: border-box; }
+      html, body { height: 100%; margin: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font: 14px/1.5 -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        display: flex;
+        flex-direction: column;
+      }
+      header {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 8px 14px;
+        background: var(--bg2);
+        border-bottom: 1px solid var(--border);
+      }
+      header .title { font-weight: 600; }
+      header .note { color: var(--muted); }
+      #status {
+        margin-left: auto;
+        font-size: 12px;
+        padding: 2px 10px;
+        border-radius: 999px;
+        background: #3a2030;
+        color: var(--accent);
+      }
+      #status.connected { background: #16351f; color: #4ade80; }
+      main { flex: 1; display: flex; min-height: 0; }
+      #editor, #preview { flex: 1; min-width: 0; overflow: auto; }
+      #editor { border-right: 1px solid var(--border); }
+      #preview { padding: 14px 20px; }
+      #preview h1, #preview h2, #preview h3 { border-bottom: 1px solid var(--border); padding-bottom: 4px; }
+      #preview pre {
+        background: var(--bg2);
+        padding: 10px 12px;
+        border-radius: 6px;
+        overflow: auto;
+      }
+      #preview code { background: var(--bg2); padding: 1px 4px; border-radius: 4px; }
+      .cm-editor { height: 100%; }
+      .hint { color: var(--muted); font-size: 12px; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <span class="title">Boostnote <span class="hint">collab PoC</span></span>
+      <span class="note" id="noteName"></span>
+      <span class="hint">— open this page in two windows to edit together</span>
+      <span id="status">connecting…</span>
+    </header>
+    <main>
+      <div id="editor"></div>
+      <div id="preview"></div>
+    </main>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/poc/collab-core/client/main.js
+++ b/poc/collab-core/client/main.js
@@ -1,0 +1,98 @@
+// Browser client for the collab PoC: a HackMD-style split editor (CodeMirror 6
+// source markdown on the left, live preview on the right) whose document is a
+// shared Yjs Y.Text synced through the self-hosted Hocuspocus server.
+//
+// This is also the prototype of the modernized app's editor pane: same CM6 +
+// markdown-it + DOMPurify pipeline, with real-time collaboration baked in.
+//
+// Open the page in two browser windows to see character-level co-editing with
+// remote cursors. Run `npm run server` first, then `npm run dev`.
+
+import { EditorView, keymap, lineNumbers } from '@codemirror/view'
+import { EditorState } from '@codemirror/state'
+import { defaultKeymap, history, historyKeymap } from '@codemirror/commands'
+import { markdown } from '@codemirror/lang-markdown'
+import { yCollab } from 'y-codemirror.next'
+import { HocuspocusProvider } from '@hocuspocus/provider'
+import * as Y from 'yjs'
+import MarkdownIt from 'markdown-it'
+import DOMPurify from 'dompurify'
+
+const params = new URLSearchParams(location.search)
+const NOTE = params.get('note') || 'note-1'
+const TOKEN = params.get('token') || 'demo-pairing-secret'
+const URL = `ws://${location.hostname}:1234`
+
+document.getElementById('noteName').textContent = `▸ ${NOTE}`
+
+const md = new MarkdownIt({ html: false, linkify: true, breaks: true })
+const preview = document.getElementById('preview')
+const statusEl = document.getElementById('status')
+
+const ydoc = new Y.Doc()
+const provider = new HocuspocusProvider({
+  url: URL,
+  name: NOTE,
+  token: TOKEN,
+  document: ydoc
+})
+const ytext = ydoc.getText('content')
+
+provider.on('status', ({ status }) => {
+  statusEl.textContent = status
+  statusEl.classList.toggle('connected', status === 'connected')
+})
+provider.on('authenticationFailed', () => {
+  statusEl.textContent = 'auth failed'
+  statusEl.classList.remove('connected')
+})
+
+// Give this client a stable identity + colour so remote cursors are visible.
+const palette = ['#ff2d75', '#4ade80', '#60a5fa', '#fbbf24', '#c084fc']
+provider.awareness.setLocalStateField('user', {
+  name: `device-${Math.floor(Math.random() * 1000)}`,
+  color: palette[Math.floor(Math.random() * palette.length)]
+})
+
+function renderPreview() {
+  // markdown-it is configured with html:false (no raw HTML), and we still
+  // sanitize with DOMPurify and inject via a parsed fragment + replaceChildren
+  // (no innerHTML) — defence in depth for untrusted note content.
+  const clean = DOMPurify.sanitize(md.render(ytext.toString()))
+  const frag = document.createRange().createContextualFragment(clean)
+  preview.replaceChildren(frag)
+}
+ytext.observe(renderPreview)
+
+const darkTheme = EditorView.theme(
+  {
+    '&': { backgroundColor: '#1e2126', color: '#d7dae0', height: '100%' },
+    '.cm-gutters': {
+      backgroundColor: '#21252b',
+      color: '#5c6370',
+      border: 'none'
+    },
+    '.cm-content': { caretColor: '#ff2d75' }
+  },
+  { dark: true }
+)
+
+new EditorView({
+  state: EditorState.create({
+    doc: ytext.toString(),
+    extensions: [
+      lineNumbers(),
+      history(),
+      keymap.of([...defaultKeymap, ...historyKeymap]),
+      markdown(),
+      darkTheme,
+      EditorView.lineWrapping,
+      // The Yjs binding: shared text + collaborative cursors (awareness) +
+      // shared undo. This is the whole collaboration integration.
+      yCollab(ytext, provider.awareness)
+    ]
+  }),
+  parent: document.getElementById('editor')
+})
+
+renderPreview()

--- a/poc/collab-core/package-lock.json
+++ b/poc/collab-core/package-lock.json
@@ -1,0 +1,1596 @@
+{
+  "name": "boostnote-collab-core-poc",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "boostnote-collab-core-poc",
+      "version": "0.1.0",
+      "dependencies": {
+        "@codemirror/commands": "^6.10.4",
+        "@codemirror/lang-markdown": "^6.5.0",
+        "@codemirror/state": "^6.7.0",
+        "@codemirror/view": "^6.43.4",
+        "@hocuspocus/provider": "^4.3.0",
+        "@hocuspocus/server": "^4.3.0",
+        "codemirror": "^6.0.2",
+        "cson": "^8.4.0",
+        "dompurify": "^3.4.11",
+        "markdown-it": "^14.2.0",
+        "ws": "^8.21.0",
+        "y-codemirror.next": "^0.3.5",
+        "yjs": "^13.6.31"
+      },
+      "devDependencies": {
+        "vite": "^8.1.0"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.4.tgz",
+      "integrity": "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.7.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
+      "integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-markdown": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.5.0.tgz",
+      "integrity": "sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.7.1",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.3.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/markdown": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.1.tgz",
+      "integrity": "sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.0.tgz",
+      "integrity": "sha512-Zbl9NyscLMZkfXPQnNAIIAFftidrA1UbcJEIMp24C0Bukc2I5T8wJS0wsXYsnDOqCFJUeJ1BITGNs5CqPDSmSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.4.tgz",
+      "integrity": "sha512-YImu23iyKfncJzT7sRy+rEqEhSc8RhOHqDxwy4WzXRKJwYm6iwf/9OJk5ctCAdZ6yi2ZqaGEvmf55fSVqMDrgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.7.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@hocuspocus/common": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/common/-/common-4.3.0.tgz",
+      "integrity": "sha512-8USsMvso01aMKOSSyvb8oTAlfES/nBM+Y74XjW5Fy5ovmOaVpoRRBrktIrEVwydrp8Cr6C66ivc0orcW/3P+Kg==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.87"
+      }
+    },
+    "node_modules/@hocuspocus/provider": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/provider/-/provider-4.3.0.tgz",
+      "integrity": "sha512-eS5dECLnJDgELI2AfZNvr5jS0B6IWFoo7eAUgwwOzy1bf7KdPagXAYCtSWqSXmLMwjABlubZJQg8FVrTefU0cA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hocuspocus/common": "^4.3.0",
+        "@lifeomic/attempt": "^3.0.2",
+        "lib0": "^0.2.87"
+      },
+      "peerDependencies": {
+        "y-protocols": "^1.0.6",
+        "yjs": "^13.6.8"
+      }
+    },
+    "node_modules/@hocuspocus/server": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/server/-/server-4.3.0.tgz",
+      "integrity": "sha512-GX9ohUJAr6aIa2ewS0EPeyf3w12wLCBBSGfc76ZMOuZJZPUzDH6BJWFjkVlaVW3OmwZ5+jxdXXFUf6sAi4EIrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hocuspocus/common": "^4.3.0",
+        "async-mutex": "^0.5.0",
+        "crossws": "^0.4.4",
+        "kleur": "^4.1.4",
+        "lib0": "^0.2.47"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "y-protocols": "^1.0.6",
+        "yjs": "^13.6.8"
+      }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.4.tgz",
+      "integrity": "sha512-N+tn9tej2hPvyKgHEApMOQfHczDJCwxrRFS3SPn9QjYN+uwHvEDnCgKRrb3mxDYxRS8sKMM8fhC3+lc04Abz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/markdown": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.6.4.tgz",
+      "integrity": "sha512-N0SxazMj4k65DBfaf1azqtMZd6u7MqluP84/NZnB/io8Td9aleFmAhz9hcbvSfsxT5tdYlJ5qgv5aMJGY4zEtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@lifeomic/attempt": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@lifeomic/attempt/-/attempt-3.1.0.tgz",
+      "integrity": "sha512-QZqem4QuAnAyzfz+Gj5/+SLxqwCAw2qmt7732ZXodr6VDWGeYLG6w1i/vYLa55JQM9wRuBKLmXmiZ2P0LtE5rw==",
+      "license": "MIT"
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.137.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
+      "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
+      "integrity": "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
+      "integrity": "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
+      "integrity": "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
+      "integrity": "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
+      "integrity": "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
+      "integrity": "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
+      "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
+      "integrity": "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
+      "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
+      "integrity": "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
+      "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
+      "integrity": "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.3.tgz",
+      "integrity": "sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
+      "integrity": "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
+      "integrity": "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
+    "node_modules/coffeescript": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.12.7.tgz",
+      "integrity": "sha512-pLXHFxQMPklVoEekowk8b3erNynC+DVJzChxS/LCBBgR6/8AJkHivkm//zbowcfc7BTCAjryuhx6gPqPRfsFoA==",
+      "license": "MIT",
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
+      "license": "MIT"
+    },
+    "node_modules/crossws": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.6.tgz",
+      "integrity": "sha512-/Wxe9Z007EbJ496j88nToZEvyPZ8PY/wjZJ18Agh/GCA9cYHyLbxtrpdFlFzAw3TV20F0SUYGl0g6PzChbwUrg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "srvx": ">=0.11.5"
+      },
+      "peerDependenciesMeta": {
+        "srvx": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cson": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/cson/-/cson-8.4.0.tgz",
+      "integrity": "sha512-QwXDbiJodA3DFEKA888zTED28EZo2JC7EK2K3qVsUVbE0oKQVRZ4K+Ch/I8QaTYPZ9Q0GXG1BFK5dtcxd6C3mg==",
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "cson-parser": "^4.0.9",
+        "extract-opts": "^5.8.0",
+        "requirefresh": "^5.13.0",
+        "safefs": "^8.9.0"
+      },
+      "bin": {
+        "cson": "bin.cjs",
+        "cson2json": "bin.cjs",
+        "json2cson": "bin.cjs"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/cson-parser": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-4.0.9.tgz",
+      "integrity": "sha512-I79SAcCYquWnEfXYj8hBqOOWKj6eH6zX1hhX3yqmS4K3bYp7jME3UFpHPzu3rUew0oyfc0s8T6IlWGXRAheHag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "coffeescript": "1.12.7"
+      },
+      "engines": {
+        "node": ">=10.13"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/eachr": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/eachr/-/eachr-7.4.0.tgz",
+      "integrity": "sha512-d6v/ERRrwxZ5oNHJz2Z5Oouge0Xc3rFxeaGNHjAhTDUCkLhy8t583ieH9/Qop1UNDTcZXOSEs8dqawmbHaEEkA==",
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "editions": "^6.21.0",
+        "typechecker": "^9.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/editions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-6.22.0.tgz",
+      "integrity": "sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ==",
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "version-range": "^4.15.0"
+      },
+      "engines": {
+        "ecmascript": ">= es5",
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/extract-opts": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/extract-opts/-/extract-opts-5.9.0.tgz",
+      "integrity": "sha512-UN5d1xtD3cQQNmE2OVsP5ij1dCDgpK5bmOxyMEXc8KaZ/YLCV0ge/RxBGG3fy7KVnxsjekwutzmzRVInQtaB4Q==",
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "eachr": "^7.4.0",
+        "editions": "^6.21.0",
+        "typechecker": "^9.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lib0": {
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
+      "license": "MIT",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.1",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/requirefresh": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/requirefresh/-/requirefresh-5.13.0.tgz",
+      "integrity": "sha512-v3BuU/AAKjDqgIig1xyekcBHtujCAghuFTOQ7YNAngEKtTksSS1vT9Abt1ilbmQFAD4ChHHGJ3JSNbqvEOIxkQ==",
+      "license": "Artistic-2.0",
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
+      "integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.137.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.3",
+        "@rolldown/binding-darwin-arm64": "1.1.3",
+        "@rolldown/binding-darwin-x64": "1.1.3",
+        "@rolldown/binding-freebsd-x64": "1.1.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.3",
+        "@rolldown/binding-linux-arm64-musl": "1.1.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-musl": "1.1.3",
+        "@rolldown/binding-openharmony-arm64": "1.1.3",
+        "@rolldown/binding-wasm32-wasi": "1.1.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.3",
+        "@rolldown/binding-win32-x64-msvc": "1.1.3"
+      }
+    },
+    "node_modules/safefs": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/safefs/-/safefs-8.10.0.tgz",
+      "integrity": "sha512-ZHnuws4iLc5vB6kxU/MpGEZO7Fz80zIEOJw6VgRAroa/PeJB/jcc2KEXxWA0Izpx+W728j398DxQRx1RU+KXIg==",
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "graceful-fs": "^4.2.11",
+        "version-compare": "^3.10.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typechecker": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-9.3.0.tgz",
+      "integrity": "sha512-7NKr0EkLaL5fkYE56DPwqgQx1FjepvDRZ64trUgb1NgeFqLkaZThI2L33vFJzN4plVyAN5zWcov57QcZIU3bjg==",
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "editions": "^6.20.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
+    "node_modules/version-compare": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/version-compare/-/version-compare-3.12.0.tgz",
+      "integrity": "sha512-okm2QaHSGDCOH58HGbfv7aWDVDvJouaZmzJF126CkWsZ7x5fQA/3pSACHM9gXPKfOvV3oOnb5gYyt8feSJqGrw==",
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "editions": "^6.21.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/version-range": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/version-range/-/version-range-4.15.0.tgz",
+      "integrity": "sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==",
+      "license": "Artistic-2.0",
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
+      "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "~1.1.2",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y-codemirror.next": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/y-codemirror.next/-/y-codemirror.next-0.3.5.tgz",
+      "integrity": "sha512-VluNu3e5HfEXybnypnsGwKAj+fKLd4iAnR7JuX1Sfyydmn1jCBS5wwEL/uS04Ch2ib0DnMAOF6ZRR/8kK3wyGw==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.42"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "yjs": "^13.5.6"
+      }
+    },
+    "node_modules/y-protocols": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
+      "integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lib0": "^0.2.85"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
+      }
+    },
+    "node_modules/yjs": {
+      "version": "13.6.31",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.31.tgz",
+      "integrity": "sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.99"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    }
+  }
+}

--- a/poc/collab-core/package.json
+++ b/poc/collab-core/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "boostnote-collab-core-poc",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "PoC: Yjs CRDT + CodeMirror 6 + self-hosted Hocuspocus + .cson snapshot write-back. Proves the collaborative-editing architecture for Boostnote modernization. NOT part of the legacy app build.",
+  "scripts": {
+    "server": "node server/hocuspocus-server.mjs",
+    "test": "node test/convergence.test.mjs",
+    "dev": "vite client",
+    "build": "vite build client"
+  },
+  "volta": {
+    "node": "22.22.3"
+  },
+  "dependencies": {
+    "@codemirror/commands": "^6.10.4",
+    "@codemirror/lang-markdown": "^6.5.0",
+    "@codemirror/state": "^6.7.0",
+    "@codemirror/view": "^6.43.4",
+    "@hocuspocus/provider": "^4.3.0",
+    "@hocuspocus/server": "^4.3.0",
+    "codemirror": "^6.0.2",
+    "cson": "^8.4.0",
+    "dompurify": "^3.4.11",
+    "markdown-it": "^14.2.0",
+    "ws": "^8.21.0",
+    "y-codemirror.next": "^0.3.5",
+    "yjs": "^13.6.31"
+  },
+  "devDependencies": {
+    "vite": "^8.1.0"
+  }
+}

--- a/poc/collab-core/server/hocuspocus-server.mjs
+++ b/poc/collab-core/server/hocuspocus-server.mjs
@@ -1,0 +1,106 @@
+// Self-hosted Hocuspocus sync server for the Boostnote collab PoC.
+//
+// Proves three things from the revised architecture decision:
+//   1. A self-hosted Yjs sync server (flat-cost, plaintext stays on our box).
+//   2. Device-pairing auth via onAuthenticate (Yjs has NO built-in access
+//      control, so the WebSocket MUST be gated — here by a shared secret).
+//   3. The "file is still the source of truth" contract: onStoreDocument
+//      writes a derived .cson snapshot in the legacy note shape, and
+//      onLoadDocument seeds a freshly-loaded doc from that snapshot.
+//
+// Run: npm run server   (Node 22 via volta)
+
+import { Server } from '@hocuspocus/server'
+import CSON from 'cson'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const DEFAULT_SNAPSHOT_DIR = path.join(__dirname, '..', 'snapshots')
+const DEFAULT_PORT = Number(process.env.PORT || 1234)
+// In the real app this is a per-device pairing token, not a hardcoded string.
+const DEFAULT_PAIRING_TOKEN = process.env.PAIRING_TOKEN || 'demo-pairing-secret'
+
+// Serialize a Yjs document to the legacy .cson note shape.
+function docToNote(doc) {
+  const meta = doc.getMap('metadata')
+  return {
+    type: meta.get('type') || 'MARKDOWN_NOTE',
+    title: meta.get('title') || '',
+    tags: meta.get('tags') || [],
+    isStarred: meta.get('isStarred') || false,
+    isTrashed: meta.get('isTrashed') || false,
+    content: doc.getText('content').toString()
+  }
+}
+
+export function createServer({
+  port = DEFAULT_PORT,
+  pairingToken = DEFAULT_PAIRING_TOKEN,
+  snapshotDir = DEFAULT_SNAPSHOT_DIR,
+  debounce = 1000
+} = {}) {
+  fs.mkdirSync(snapshotDir, { recursive: true })
+  const snapshotPath = name => path.join(snapshotDir, `${name}.cson`)
+
+  return new Server({
+    port,
+    // Flush the snapshot at most once per `debounce` ms per document
+    // (Hocuspocus debounces onStoreDocument internally; mirrors the app's 1s).
+    debounce,
+    quiet: true,
+
+    // --- Security gate: device pairing -------------------------------------
+    // Without this, anyone who can reach the socket and knows a document name
+    // can read/write it. The token is verified before any sync happens.
+    async onAuthenticate({ token }) {
+      if (token !== pairingToken) {
+        throw new Error('Not authorized: invalid device-pairing token')
+      }
+      return { device: 'paired' }
+    },
+
+    // --- Seed a freshly loaded doc from its .cson snapshot -----------------
+    async onLoadDocument({ document, documentName }) {
+      const file = snapshotPath(documentName)
+      const ytext = document.getText('content')
+      // Only seed if the in-memory doc is still empty, so we never duplicate
+      // content that clients have already synced.
+      if (ytext.length === 0 && fs.existsSync(file)) {
+        const note = CSON.parse(fs.readFileSync(file, 'utf8'))
+        if (note && typeof note.content === 'string') {
+          ytext.insert(0, note.content)
+        }
+        const meta = document.getMap('metadata')
+        for (const key of ['type', 'title', 'tags', 'isStarred', 'isTrashed']) {
+          if (note && note[key] !== undefined) meta.set(key, note[key])
+        }
+      }
+      return document
+    },
+
+    // --- Persist a derived .cson snapshot ----------------------------------
+    async onStoreDocument({ document, documentName }) {
+      const note = docToNote(document)
+      const out = CSON.stringify(note, null, 2)
+      fs.writeFileSync(snapshotPath(documentName), out)
+      // eslint-disable-next-line no-console
+      console.log(
+        `[snapshot] ${documentName}.cson <- ${note.content.length} chars`
+      )
+    }
+  })
+}
+
+// Start when run directly (not when imported by the test).
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const server = createServer()
+  server.listen().then(() => {
+    // eslint-disable-next-line no-console
+    console.log(
+      `Hocuspocus listening on ws://127.0.0.1:${DEFAULT_PORT}  (pairing token: "${DEFAULT_PAIRING_TOKEN}")\n` +
+        `Snapshots -> ${DEFAULT_SNAPSHOT_DIR}`
+    )
+  })
+}

--- a/poc/collab-core/test/convergence.test.mjs
+++ b/poc/collab-core/test/convergence.test.mjs
@@ -1,0 +1,161 @@
+// Headless proof of the collaborative-editing architecture.
+//
+// No browser needed: we spin up the self-hosted Hocuspocus server and connect
+// TWO Yjs clients (as two devices) to the same note, then assert:
+//   1. device-pairing auth REJECTS a wrong token,
+//   2. an edit on device A converges to device B (character-level CRDT merge),
+//   3. concurrent edits from both devices both survive (no lost write),
+//   4. the server writes a derived .cson snapshot in the legacy note shape.
+//
+// Run: npm test   (Node 22 via volta)
+
+import { HocuspocusProvider } from '@hocuspocus/provider'
+import * as Y from 'yjs'
+import { WebSocket } from 'ws'
+import CSON from 'cson'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { createServer } from '../server/hocuspocus-server.mjs'
+
+const PORT = 7777
+const TOKEN = 'demo-pairing-secret'
+const SNAPSHOT_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'collab-poc-'))
+const URL = `ws://127.0.0.1:${PORT}`
+
+const sleep = ms => new Promise(r => setTimeout(r, ms))
+
+function connect(name, token = TOKEN) {
+  const doc = new Y.Doc()
+  const provider = new HocuspocusProvider({
+    url: URL,
+    name,
+    token,
+    document: doc,
+    WebSocketPolyfill: WebSocket,
+    connect: true
+  })
+  return { doc, provider }
+}
+
+async function waitFor(predicate, { timeout = 5000, label = 'condition' } = {}) {
+  const start = Date.now()
+  while (Date.now() - start < timeout) {
+    if (predicate()) return
+    await sleep(25)
+  }
+  throw new Error(`Timed out waiting for: ${label}`)
+}
+
+let pass = 0
+const ok = msg => {
+  pass++
+  // eslint-disable-next-line no-console
+  console.log(`  ✓ ${msg}`)
+}
+
+async function main() {
+  const server = createServer({
+    port: PORT,
+    pairingToken: TOKEN,
+    snapshotDir: SNAPSHOT_DIR,
+    debounce: 200
+  })
+  await server.listen()
+
+  // --- 1. Auth gate rejects an unpaired device ---------------------------
+  {
+    const bad = connect('note-auth', 'wrong-token')
+    let rejected = false
+    bad.provider.on('authenticationFailed', () => {
+      rejected = true
+    })
+    await waitFor(() => rejected, { label: 'auth rejection of wrong token' })
+    ok('device-pairing auth rejects an invalid token')
+    bad.provider.destroy()
+  }
+
+  // --- 2 & 3. Two paired devices on the same note converge ---------------
+  const NOTE = 'note-1'
+  const a = connect(NOTE)
+  const b = connect(NOTE)
+  await waitFor(() => a.provider.isSynced && b.provider.isSynced, {
+    label: 'both devices synced'
+  })
+  ok('two paired devices connect and sync')
+
+  // Device A types.
+  a.doc.getText('content').insert(0, 'Hello from device A. ')
+  await waitFor(
+    () => b.doc.getText('content').toString().includes('Hello from device A.'),
+    { label: 'A -> B convergence' }
+  )
+  ok('an edit on device A converges to device B')
+
+  // Concurrent edits from both devices (prepend on A, append on B).
+  const beforeLen = b.doc.getText('content').length
+  a.doc.getText('content').insert(0, '[A-prepend] ')
+  b.doc.getText('content').insert(beforeLen, ' [B-append]')
+  await waitFor(
+    () => {
+      const ta = a.doc.getText('content').toString()
+      const tb = b.doc.getText('content').toString()
+      return (
+        ta === tb &&
+        ta.includes('[A-prepend]') &&
+        ta.includes('[B-append]') &&
+        ta.includes('Hello from device A.')
+      )
+    },
+    { label: 'concurrent edits converge with no lost write' }
+  )
+  const converged = a.doc.getText('content').toString()
+  assert.equal(converged, b.doc.getText('content').toString())
+  ok(`concurrent edits both survive and converge: "${converged}"`)
+
+  // Set some metadata (title) the way the app would.
+  a.doc.getMap('metadata').set('title', 'Collab PoC Note')
+  a.doc.getMap('metadata').set('type', 'MARKDOWN_NOTE')
+
+  // --- 4. Server persisted a derived .cson snapshot ----------------------
+  const snapshotFile = path.join(SNAPSHOT_DIR, `${NOTE}.cson`)
+  await waitFor(() => fs.existsSync(snapshotFile), {
+    label: '.cson snapshot written',
+    timeout: 4000
+  })
+  // Give the debounced writer a beat to capture the latest state.
+  await sleep(400)
+  const note = CSON.parse(fs.readFileSync(snapshotFile, 'utf8'))
+  assert.equal(note.content, converged)
+  assert.equal(note.type, 'MARKDOWN_NOTE')
+  ok(`server wrote a legacy-shaped .cson snapshot (title="${note.title}")`)
+
+  // --- 5. A late-joining device loads from the snapshot ------------------
+  // Drop both clients so the server unloads the in-memory doc, then reconnect.
+  a.provider.destroy()
+  b.provider.destroy()
+  await sleep(600)
+  const c = connect(NOTE)
+  await waitFor(() => c.provider.isSynced, { label: 'late device synced' })
+  await waitFor(
+    () => c.doc.getText('content').toString().includes('Hello from device A.'),
+    { label: 'late device seeded from .cson snapshot' }
+  )
+  ok('a late-joining device is seeded from the .cson snapshot')
+  c.provider.destroy()
+
+  await server.destroy()
+  fs.rmSync(SNAPSHOT_DIR, { recursive: true, force: true })
+  // eslint-disable-next-line no-console
+  console.log(`\nAll ${pass} checks passed — collab core architecture validated.`)
+}
+
+main().then(
+  () => process.exit(0),
+  err => {
+    // eslint-disable-next-line no-console
+    console.error('\n✗ FAILED:', err && err.message ? err.message : err)
+    process.exit(1)
+  }
+)


### PR DESCRIPTION
モダナイゼーションの最難関（**リアルタイム共同編集を local-first＋「ファイルが本体」のまま実現**）を de-risk する独立 PoC。現行 legacy app のビルドとは分離（`poc/` は legacy lint/CI 対象外、独自 package.json/Node 22）。

## 検証済み（ヘッドレス・ブラウザ不要）
`npm test` → **All 6 checks passed**:
1. device-pairing 認証が不正トークンを拒否（Yjs に ACL は無いので必須）
2. 2端末が接続・同期
3. 端末A→B へ収束
4. **同時編集が両方残り収束**（編集消失なし）— CRDT
5. サーバが legacy 形状の `.cson` スナップショットを書き出し
6. 後から参加した端末が `.cson` からシード

## 構成
- `server/hocuspocus-server.mjs` — Hocuspocus。`onAuthenticate`(pairing) / `onLoadDocument`(seed from .cson) / `onStoreDocument`(write .cson)
- `test/convergence.test.mjs` — 上記の自動証明
- `client/` — HackMD 風の分割エディタ（CM6 + y-codemirror.next 共同カーソル / markdown-it + DOMPurify プレビュー）。**実アプリのエディタ部の試作**。`vite build` 通過

GPL-3.0 継承。次段: Yjs update log の永続化（履歴/undo の再起動耐性）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * リアルタイム共同編集の新しいPoCと運用方針を追加しました。
  * 分割エディタでMarkdown編集とプレビューを並べて表示できるようになりました。
  * デバイス間同期、認証付き接続、変更内容のスナップショット保存に対応しました。

* **Tests**
  * 共同編集の同期、一致性、再接続時の復元を検証するテストを追加しました。

* **Chores**
  * 開発対象外のパス整理と、PoC関連ファイルの管理設定を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->