### PR TITLE
fix: correct codemirror-mode-elixir script path (404 on every launch)

### DIFF
--- a/lib/main.development.html
+++ b/lib/main.development.html
@@ -96,7 +96,7 @@
 
   <script src="../node_modules/codemirror/lib/codemirror.js"></script>
   <script src="../node_modules/codemirror/mode/meta.js"></script>
-  <script src="../node_modules/codemirror-mode-elixir/dist/elixir.js"></script>
+  <script src="../node_modules/codemirror-mode-elixir/dist/codemirror-mode-elixir.umd.js"></script>
   <script src="../node_modules/codemirror/addon/mode/overlay.js"></script>
   <script src="../node_modules/codemirror/addon/mode/loadmode.js"></script>
   <script src="../node_modules/codemirror/addon/mode/simple.js"></script>

--- a/lib/main.production.html
+++ b/lib/main.production.html
@@ -92,7 +92,7 @@
 
   <script src="../node_modules/codemirror/lib/codemirror.js"></script>
   <script src="../node_modules/codemirror/mode/meta.js"></script>
-  <script src="../node_modules/codemirror-mode-elixir/dist/elixir.js"></script>
+  <script src="../node_modules/codemirror-mode-elixir/dist/codemirror-mode-elixir.umd.js"></script>
   <script src="../node_modules/codemirror/addon/mode/overlay.js"></script>
   <script src="../node_modules/codemirror/addon/mode/loadmode.js"></script>
   <script src="../node_modules/codemirror/addon/mode/simple.js"></script>


### PR DESCRIPTION
#51（flowchart）と同類の壊れた依存。HTMLが `codemirror-mode-elixir/dist/elixir.js` を参照するが、`^1.1.1`→1.1.2 で配布物が `dist/codemirror-mode-elixir.umd.js` に変わり、`<script>` が毎起動 **404**。

webpack バンドル側の `import 'codemirror-mode-elixir'`（MarkdownPreview）でも読まれるため**致命的ではない**（mode は動く）が、dead reference。実在する UMD（`defineMode('elixir')` をグローバル CodeMirror に登録）へ修正。lint クリーン。

「古いパッケージ早急対処」の一環。全 HTML `<script>` 依存を一括検証し、残りは全て実在を確認済み（壊れているのは flowchart=修正済 と elixir=本PR の2件のみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)