### PR TITLE
app: data-layer seam + virtualized note list (scale & performance)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,6 +1,6 @@
-import { useMemo, useState } from 'react'
-import type { Note, Selection } from './types'
-import { sampleNotes, sampleStorages } from './data/sampleNotes'
+import { useEffect, useMemo, useState } from 'react'
+import type { Note, Selection, Storage } from './types'
+import { createInMemoryRepository } from './data/repository'
 import { Sidebar } from './components/Sidebar'
 import { NoteList } from './components/NoteList'
 import { MarkdownEditor } from './components/MarkdownEditor'
@@ -12,15 +12,30 @@ function firstTitle(content: string, fallback: string) {
   return line.replace(/^#+\s*/, '').trim() || fallback
 }
 
+// The data-layer seam: swap this for the Electron `.cson` repository later.
+const repository = createInMemoryRepository()
+
 export default function App() {
-  const [notes, setNotes] = useState<Note[]>(sampleNotes)
+  const [notes, setNotes] = useState<Note[]>([])
+  const [storages, setStorages] = useState<Storage[]>([])
   const [selection, setSelection] = useState<Selection>({
     kind: 'smart',
     value: 'all'
   })
-  const [activeKey, setActiveKey] = useState<string | null>(
-    sampleNotes[0]?.key ?? null
-  )
+  const [activeKey, setActiveKey] = useState<string | null>(null)
+
+  useEffect(() => {
+    let alive = true
+    repository.load().then(({ storages, notes }) => {
+      if (!alive) return
+      setStorages(storages)
+      setNotes(notes)
+      setActiveKey(prev => prev ?? notes[0]?.key ?? null)
+    })
+    return () => {
+      alive = false
+    }
+  }, [])
 
   const visible = useMemo(() => {
     const live = notes.filter(n => !n.isTrashed)
@@ -78,7 +93,7 @@ export default function App() {
   }
 
   const folderName = active
-    ? (sampleStorages
+    ? (storages
         .find(s => s.key === active.storage)
         ?.folders.find(f => f.key === active.folder)?.name ?? active.folder)
     : ''
@@ -86,7 +101,7 @@ export default function App() {
   return (
     <div className="app">
       <Sidebar
-        storages={sampleStorages}
+        storages={storages}
         notes={notes}
         selection={selection}
         onSelect={selectView}

--- a/app/src/components/NoteList.tsx
+++ b/app/src/components/NoteList.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type { Note } from '../types'
 
 interface Props {
@@ -6,45 +7,91 @@ interface Props {
   onSelect: (key: string) => void
 }
 
-function relTime(iso: string) {
+const ROW_H = 58 // fixed row height enables simple, fast windowing
+const OVERSCAN = 6
+
+function shortDate(iso: string) {
   const d = new Date(iso)
   return `${d.getFullYear()}/${d.getMonth() + 1}/${d.getDate()}`
 }
 
+/**
+ * Virtualized note list: only the rows in (and just around) the viewport are
+ * rendered, so hundreds of notes scroll smoothly. Sorted by Updated desc.
+ */
 export function NoteList({ notes, activeKey, onSelect }: Props) {
-  const sorted = [...notes].sort(
-    (a, b) => +new Date(b.updatedAt) - +new Date(a.updatedAt)
+  const sorted = useMemo(
+    () =>
+      [...notes].sort((a, b) => +new Date(b.updatedAt) - +new Date(a.updatedAt)),
+    [notes]
   )
+
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const [scrollTop, setScrollTop] = useState(0)
+  const [viewport, setViewport] = useState(800)
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const update = () => setViewport(el.clientHeight)
+    update()
+    const ro = new ResizeObserver(update)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+
+  const total = sorted.length
+  const start = Math.max(0, Math.floor(scrollTop / ROW_H) - OVERSCAN)
+  const end = Math.min(total, Math.ceil((scrollTop + viewport) / ROW_H) + OVERSCAN)
+  const windowed = sorted.slice(start, end)
+
   return (
     <section className="notelist">
       <div className="notelist-head">
         <span>⌄ Updated</span>
         <span className="sort" style={{ marginLeft: 'auto' }}>
-          {notes.length} notes
+          {total} notes
         </span>
       </div>
-      <div className="notelist-scroll">
-        {sorted.map(note => (
-          <div
-            key={note.key}
-            className={`note-row ${note.key === activeKey ? 'active' : ''}`}
-            onClick={() => onSelect(note.key)}
-          >
-            <div className="note-title">
-              <span className="ic">
-                {note.type === 'SNIPPET_NOTE' ? '〈〉' : '▤'}
-              </span>
-              {note.title || 'Untitled'}
-            </div>
-            <div className="note-meta">
-              {relTime(note.updatedAt)}
-              {note.tags.length > 0 && ` · ${note.tags.map(t => `#${t}`).join(' ')}`}
-            </div>
-          </div>
-        ))}
-        {sorted.length === 0 && (
-          <div style={{ padding: 20, color: 'var(--faint)' }}>No notes</div>
-        )}
+      <div
+        className="notelist-scroll"
+        ref={scrollRef}
+        onScroll={e => setScrollTop(e.currentTarget.scrollTop)}
+      >
+        <div style={{ height: total * ROW_H, position: 'relative' }}>
+          {windowed.map((note, idx) => {
+            const i = start + idx
+            return (
+              <div
+                key={note.key}
+                className={`note-row ${note.key === activeKey ? 'active' : ''}`}
+                style={{
+                  position: 'absolute',
+                  top: i * ROW_H,
+                  left: 0,
+                  right: 0,
+                  height: ROW_H
+                }}
+                onClick={() => onSelect(note.key)}
+              >
+                <div className="note-title">
+                  <span className="ic">
+                    {note.type === 'SNIPPET_NOTE' ? '〈〉' : '▤'}
+                  </span>
+                  {note.title || 'Untitled'}
+                </div>
+                <div className="note-meta">
+                  {shortDate(note.updatedAt)}
+                  {note.tags.length > 0 &&
+                    ` · ${note.tags.map(t => `#${t}`).join(' ')}`}
+                </div>
+              </div>
+            )
+          })}
+          {total === 0 && (
+            <div style={{ padding: 20, color: 'var(--faint)' }}>No notes</div>
+          )}
+        </div>
       </div>
     </section>
   )

--- a/app/src/data/repository.ts
+++ b/app/src/data/repository.ts
@@ -1,0 +1,62 @@
+import type { Note, Storage } from '../types'
+import { sampleNotes, sampleStorages } from './sampleNotes'
+
+/**
+ * The data-layer seam. The renderer only ever talks to a NotesRepository;
+ * the Electron build will provide an implementation that reads/writes real
+ * `.cson` files in the main process and bridges them over IPC. The browser
+ * foundation uses an in-memory repository seeded with sample data.
+ */
+export interface NotesRepository {
+  load(): Promise<{ storages: Storage[]; notes: Note[] }>
+}
+
+// Deterministic (no Math.random) generator so the list reaches realistic
+// scale (~the user's 274 notes) for virtualization, without flaky output.
+function generateNotes(count: number): Note[] {
+  const folders = sampleStorages[0].folders
+  const titles = [
+    'SEO改善レビュー',
+    'API 設計メモ',
+    'パフォーマンス計測',
+    'リリースノート',
+    'ミーティング議事録',
+    'バグ調査ログ',
+    'インフラ構成',
+    'デザインレビュー',
+    'スプリント計画',
+    'リサーチ'
+  ]
+  const out: Note[] = []
+  for (let i = 0; i < count; i++) {
+    const folder = folders[i % folders.length]
+    const base = titles[i % titles.length]
+    const day = ((i * 7) % 27) + 1
+    const month = ((i * 3) % 11) + 1
+    out.push({
+      key: `gen-${i}`,
+      type: i % 5 === 0 ? 'SNIPPET_NOTE' : 'MARKDOWN_NOTE',
+      title: `${base} #${i + 1}`,
+      tags: i % 3 === 0 ? ['wip'] : i % 4 === 0 ? ['done', 'review'] : [],
+      storage: 'client',
+      folder: folder.key,
+      isStarred: i % 11 === 0,
+      isTrashed: false,
+      createdAt: new Date(2025, month - 1, day).toISOString(),
+      updatedAt: new Date(2025, month - 1, day, (i % 23) + 1).toISOString(),
+      content: `# ${base} #${i + 1}\n\nフォルダ: **${folder.name}**\n\n- 項目 A\n- 項目 B\n\n\`\`\`ts\nconst x = ${i}\n\`\`\`\n`
+    })
+  }
+  return out
+}
+
+/** In-memory repository: the 8 curated notes + generated notes for scale. */
+export function createInMemoryRepository(scaleTo = 280): NotesRepository {
+  const extra = Math.max(0, scaleTo - sampleNotes.length)
+  const notes = [...sampleNotes, ...generateNotes(extra)]
+  return {
+    async load() {
+      return { storages: sampleStorages, notes }
+    }
+  }
+}


### PR DESCRIPTION
モダンアプリ土台の次スライス。「まず高速・安定」方針に沿って、実ノート表示に向けた**データ層の seam ＋ 仮想化**。

- **`NotesRepository` インターフェース**＝データ層の差し込み口。レンダラはリポジトリ越しにのみノートを扱う。Electron 版が main プロセスで実 `.cson` を読み書きして IPC で渡す実装を提供（ブラウザ土台は in-memory）。
- `createInMemoryRepository` が **約280件**（決定的ジェネレータ）にスケール → 実データ規模(~274)でリストを検証。
- **`NoteList` を仮想化**（固定58px行 + scrollTop/ResizeObserver ウィンドウイング）→ 数百件でも**表示行だけ描画**して滑らかにスクロール。Updated降順。
- App はリポジトリから async ロード（IPC 対応形）。

型チェック付き本番ビルド通過（`tsc -b && vite build`）。モダンCI（`app` ジョブ）が検証。

次: Electron ラッパ＋実 `.cson` リーダ（このリポジトリ実装を差し替え）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * アプリ起動時にデータを非同期で読み込むようになり、表示内容が動的に反映されるようになりました。
  * ノート一覧が大量データでも快適に表示されるよう、表示中の項目だけを描画する方式に対応しました。

* **改善**
  * サイドバーやフォルダ表示が、読み込み済みの最新データを参照するようになりました。
  * ノート一覧の件数表示や空状態の判定が、実際の表示対象に合わせて更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->