### PR TITLE
app: Electron shell + real .cson reader (samples → real notes)

### DIFF
--- a/.github/workflows/modern.yml
+++ b/.github/workflows/modern.yml
@@ -1,10 +1,10 @@
 name: Modern workspaces
 
-# Type-checks/builds the modern app shell and runs the collab-core PoC tests
-# on Node 22. These workspaces are intentionally separate from the legacy
-# Electron app (which is pinned to Node 14 in ci.yml). Path filters keep this
-# from running on unrelated legacy changes. No untrusted event input is
-# referenced in any run: step.
+# Type-checks/builds the modern app shell, runs its data-layer tests, and runs
+# the collab-core PoC tests on Node 22. Separate from the legacy Electron app
+# (Node 14, ci.yml). Path-filtered to app/** and poc/**. All run: steps are
+# static commands (no untrusted event input). The app job skips the Electron
+# binary download (not needed to type-check/build/test).
 
 on:
   push:
@@ -22,12 +22,14 @@ on:
   workflow_dispatch:
 
 jobs:
-  app-build:
-    name: app — type-check & build
+  app:
+    name: app — type-check, build & test
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: app
+    env:
+      ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,6 +43,8 @@ jobs:
         run: npm ci
       - name: Type-check & build
         run: npm run build
+      - name: Data-layer tests
+        run: npm test
 
   poc-collab-core:
     name: poc/collab-core — convergence test

--- a/app/README.md
+++ b/app/README.md
@@ -24,9 +24,26 @@ collab). This is **not** the legacy Electron app (the legacy lint/CI ignore `app
 ```bash
 # Node 22 (the legacy app uses Node 14; this is a separate modern workspace)
 npm install
-npm run dev      # Vite dev server
+npm run dev      # Vite dev server (browser; in-memory sample data)
 npm run build    # tsc -b && vite build (type-checked production build)
+npm test         # node --test: .cson data-layer tests
+
+# Desktop app (Electron 42), reading your REAL .cson notes:
+npm run build
+BOOSTNOTE_STORAGE="/path/to/your/storage" npm run electron
+#   BOOSTNOTE_STORAGE = path-separated list of legacy Boostnote storage roots
+#   (each a folder with boostnote.json + notes/*.cson). Inside Electron the app
+#   reads them via the preload bridge; in the browser it falls back to samples.
 ```
+
+## Architecture (data layer)
+
+- `electron/loadNotes.cjs` — pure Node reader: `boostnote.json` + `notes/*.cson`
+  → the app's `Note` shape (unit-tested, no Electron needed).
+- `electron/main.cjs` / `electron/preload.cjs` — secure shell (contextIsolation,
+  sandbox, no nodeIntegration); one IPC channel `notes:load`.
+- `src/data/repository.ts` — `createRepository()` picks the Electron reader when
+  `window.boostnote` exists, else the in-memory sample repo.
 
 ## Roadmap (next slices)
 

--- a/app/electron/loadNotes.cjs
+++ b/app/electron/loadNotes.cjs
@@ -1,0 +1,80 @@
+'use strict'
+
+// Reads legacy Boostnote `.cson` storages from disk into the app's Note shape.
+// A "storage" is a folder containing `boostnote.json` (folder list) and a
+// `notes/` subdir of `<key>.cson` files. This is the core of the Electron
+// data layer; it is pure Node so it can be unit-tested without Electron.
+
+const fs = require('node:fs')
+const path = require('node:path')
+const CSON = require('cson-parser')
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'))
+}
+
+function toNote(raw, key, storageKey) {
+  return {
+    key,
+    type: raw.type === 'SNIPPET_NOTE' ? 'SNIPPET_NOTE' : 'MARKDOWN_NOTE',
+    title: typeof raw.title === 'string' ? raw.title : '',
+    content: typeof raw.content === 'string' ? raw.content : '',
+    tags: Array.isArray(raw.tags) ? raw.tags.filter(t => typeof t === 'string') : [],
+    storage: storageKey,
+    folder: typeof raw.folder === 'string' ? raw.folder : '',
+    isStarred: !!raw.isStarred,
+    isTrashed: !!raw.isTrashed,
+    createdAt: String(raw.createdAt || ''),
+    updatedAt: String(raw.updatedAt || raw.createdAt || '')
+  }
+}
+
+/**
+ * Load one storage directory.
+ * @param {string} rootDir  storage folder (contains boostnote.json + notes/)
+ * @param {string} [storageKey]
+ * @returns {{ storage: object, notes: object[] }}
+ */
+function loadStorage(rootDir, storageKey) {
+  const key = storageKey || path.basename(rootDir)
+  const meta = readJson(path.join(rootDir, 'boostnote.json'))
+  const storage = {
+    key,
+    name: meta.name || path.basename(rootDir),
+    folders: (meta.folders || []).map(f => ({
+      key: f.key,
+      name: f.name,
+      color: f.color
+    }))
+  }
+
+  const notesDir = path.join(rootDir, 'notes')
+  const notes = []
+  if (fs.existsSync(notesDir)) {
+    for (const file of fs.readdirSync(notesDir)) {
+      if (!file.endsWith('.cson')) continue
+      const raw = CSON.parse(fs.readFileSync(path.join(notesDir, file), 'utf8'))
+      notes.push(toNote(raw, file.replace(/\.cson$/, ''), key))
+    }
+  }
+  return { storage, notes }
+}
+
+/**
+ * Load several storage roots and aggregate them.
+ * @param {string[]} roots
+ * @returns {{ storages: object[], notes: object[] }}
+ */
+function loadStorages(roots) {
+  const storages = []
+  const notes = []
+  for (const root of roots) {
+    if (!root || !fs.existsSync(path.join(root, 'boostnote.json'))) continue
+    const { storage, notes: ns } = loadStorage(root)
+    storages.push(storage)
+    notes.push(...ns)
+  }
+  return { storages, notes }
+}
+
+module.exports = { loadStorage, loadStorages, toNote }

--- a/app/electron/main.cjs
+++ b/app/electron/main.cjs
@@ -1,0 +1,57 @@
+'use strict'
+
+// Minimal, secure Electron shell for the modern app. Loads the Vite-built
+// renderer and bridges a single IPC channel that reads the user's real
+// `.cson` storages from disk (BOOSTNOTE_STORAGE = path-separated storage roots).
+//
+//   npm run build && BOOSTNOTE_STORAGE=/path/to/storage npm run electron
+
+const { app, BrowserWindow, ipcMain } = require('electron')
+const path = require('node:path')
+const { loadStorages } = require('./loadNotes.cjs')
+
+function storageRoots() {
+  const raw = process.env.BOOSTNOTE_STORAGE
+  return raw ? raw.split(path.delimiter).filter(Boolean) : []
+}
+
+ipcMain.handle('notes:load', () => {
+  try {
+    return loadStorages(storageRoots())
+  } catch (err) {
+    console.error('notes:load failed:', err)
+    return { storages: [], notes: [], error: String(err) }
+  }
+})
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    backgroundColor: '#1e2126',
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.cjs'),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true
+    }
+  })
+
+  const devUrl = process.env.VITE_DEV_SERVER_URL
+  if (devUrl) {
+    win.loadURL(devUrl)
+  } else {
+    win.loadFile(path.join(__dirname, '..', 'dist', 'index.html'))
+  }
+}
+
+app.whenReady().then(() => {
+  createWindow()
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow()
+  })
+})
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit()
+})

--- a/app/electron/preload.cjs
+++ b/app/electron/preload.cjs
@@ -1,0 +1,10 @@
+'use strict'
+
+// Exposes a minimal, safe surface to the renderer. The renderer never gets
+// Node or ipcRenderer directly — only this typed `window.boostnote` API.
+
+const { contextBridge, ipcRenderer } = require('electron')
+
+contextBridge.exposeInMainWorld('boostnote', {
+  loadNotes: () => ipcRenderer.invoke('notes:load')
+})

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -13,6 +13,7 @@
         "@codemirror/state": "^6.7.0",
         "@codemirror/view": "^6.43.4",
         "codemirror": "^6.0.2",
+        "cson-parser": "^4.0.9",
         "dompurify": "^3.4.11",
         "markdown-it": "^14.2.0",
         "react": "^19.2.7",
@@ -24,6 +25,7 @@
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.2",
+        "electron": "^42.5.0",
         "oxlint": "^1.69.0",
         "typescript": "~6.0.2",
         "vite": "^8.1.0"
@@ -168,6 +170,37 @@
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.4.tgz",
+      "integrity": "sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
+      "integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
+        "progress": "^2.0.3",
+        "semver": "^7.6.3",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "optionalDependencies": {
+        "undici": "^7.24.4"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1013,11 +1046,36 @@
         "@codemirror/view": "^6.0.0"
       }
     },
+    "node_modules/coffeescript": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.12.7.tgz",
+      "integrity": "sha512-pLXHFxQMPklVoEekowk8b3erNynC+DVJzChxS/LCBBgR6/8AJkHivkm//zbowcfc7BTCAjryuhx6gPqPRfsFoA==",
+      "license": "MIT",
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/crelt": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
       "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
       "license": "MIT"
+    },
+    "node_modules/cson-parser": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-4.0.9.tgz",
+      "integrity": "sha512-I79SAcCYquWnEfXYj8hBqOOWKj6eH6zX1hhX3yqmS4K3bYp7jME3UFpHPzu3rUew0oyfc0s8T6IlWGXRAheHag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "coffeescript": "1.12.7"
+      },
+      "engines": {
+        "node": ">=10.13"
+      }
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -1025,6 +1083,24 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1045,6 +1121,25 @@
         "@types/trusted-types": "^2.0.7"
       }
     },
+    "node_modules/electron": {
+      "version": "42.5.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.5.0.tgz",
+      "integrity": "sha512-cYEKS9XFz+c9fAB4jI0x49yz1FFzB55r3q96wu9YkwwJMv7t9202IE/ltlgy6yitl/J4M7C8JQcmUqdzDvPl/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0"
+      },
+      "bin": {
+        "electron": "cli.js",
+        "install-electron": "install.js"
+      },
+      "engines": {
+        "node": ">= 22.12.0"
+      }
+    },
     "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -1055,6 +1150,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/fdir": {
@@ -1089,6 +1197,13 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -1403,6 +1518,13 @@
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "license": "MIT"
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.15",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
@@ -1520,6 +1642,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/punycode.js": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
@@ -1590,6 +1722,19 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1605,6 +1750,19 @@
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "license": "MIT"
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
@@ -1650,6 +1808,17 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.18.2",

--- a/app/package.json
+++ b/app/package.json
@@ -3,11 +3,15 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "main": "electron/main.cjs",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "test": "node --test test/*.test.mjs",
     "lint": "oxlint",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "electron": "electron .",
+    "electron:dev": "VITE_DEV_SERVER_URL=http://localhost:5173 electron ."
   },
   "dependencies": {
     "@codemirror/commands": "^6.10.4",
@@ -15,6 +19,7 @@
     "@codemirror/state": "^6.7.0",
     "@codemirror/view": "^6.43.4",
     "codemirror": "^6.0.2",
+    "cson-parser": "^4.0.9",
     "dompurify": "^3.4.11",
     "markdown-it": "^14.2.0",
     "react": "^19.2.7",
@@ -26,6 +31,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
+    "electron": "^42.5.0",
     "oxlint": "^1.69.0",
     "typescript": "~6.0.2",
     "vite": "^8.1.0"

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { Note, Selection, Storage } from './types'
-import { createInMemoryRepository } from './data/repository'
+import { createRepository } from './data/repository'
 import { Sidebar } from './components/Sidebar'
 import { NoteList } from './components/NoteList'
 import { MarkdownEditor } from './components/MarkdownEditor'
@@ -12,8 +12,8 @@ function firstTitle(content: string, fallback: string) {
   return line.replace(/^#+\s*/, '').trim() || fallback
 }
 
-// The data-layer seam: swap this for the Electron `.cson` repository later.
-const repository = createInMemoryRepository()
+// The data-layer seam: real `.cson` files in Electron, sample data in browser.
+const repository = createRepository()
 
 export default function App() {
   const [notes, setNotes] = useState<Note[]>([])

--- a/app/src/data/repository.ts
+++ b/app/src/data/repository.ts
@@ -60,3 +60,25 @@ export function createInMemoryRepository(scaleTo = 280): NotesRepository {
     }
   }
 }
+
+/** Reads the user's real `.cson` storages over the Electron preload bridge. */
+export function createElectronRepository(): NotesRepository {
+  return {
+    async load() {
+      const res = await window.boostnote!.loadNotes()
+      return { storages: res.storages, notes: res.notes }
+    }
+  }
+}
+
+/**
+ * Pick the repository for the current runtime: real `.cson` files when running
+ * inside Electron (the preload exposed `window.boostnote`), otherwise the
+ * in-memory sample data for the browser foundation.
+ */
+export function createRepository(): NotesRepository {
+  if (typeof window !== 'undefined' && window.boostnote) {
+    return createElectronRepository()
+  }
+  return createInMemoryRepository()
+}

--- a/app/src/electron.d.ts
+++ b/app/src/electron.d.ts
@@ -1,0 +1,17 @@
+import type { Note, Storage } from './types'
+
+// The preload bridge (electron/preload.cjs). Present only when running inside
+// Electron; the browser foundation falls back to the in-memory repository.
+declare global {
+  interface Window {
+    boostnote?: {
+      loadNotes(): Promise<{
+        storages: Storage[]
+        notes: Note[]
+        error?: string
+      }>
+    }
+  }
+}
+
+export {}

--- a/app/test/loadNotes.test.mjs
+++ b/app/test/loadNotes.test.mjs
@@ -1,0 +1,92 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const { loadStorage, loadStorages } = require('../electron/loadNotes.cjs')
+
+function makeStorage() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bn-storage-'))
+  fs.writeFileSync(
+    path.join(root, 'boostnote.json'),
+    JSON.stringify({
+      name: 'client',
+      folders: [
+        { key: 'aim', name: 'AIM', color: '#e6b800' },
+        { key: 'kdd', name: 'KDD', color: '#4ade80' }
+      ]
+    })
+  )
+  const notesDir = path.join(root, 'notes')
+  fs.mkdirSync(notesDir)
+  fs.writeFileSync(
+    path.join(notesDir, 'abc123.cson'),
+    `createdAt: '2025-12-03T10:00:00.000Z'
+updatedAt: '2025-12-03T10:00:00.000Z'
+type: 'MARKDOWN_NOTE'
+folder: 'aim'
+title: 'CLS 改善計画'
+tags: ['perf', 'seo']
+isStarred: true
+isTrashed: false
+content: '''
+# CLS 改善計画
+
+- a
+- b
+'''`
+  )
+  fs.writeFileSync(
+    path.join(notesDir, 'def456.cson'),
+    `type: 'SNIPPET_NOTE'
+folder: 'kdd'
+title: 'snippet'
+tags: []
+content: 'x'`
+  )
+  // A non-.cson file must be ignored.
+  fs.writeFileSync(path.join(notesDir, 'README.txt'), 'ignore me')
+  return root
+}
+
+test('loadStorage parses boostnote.json + notes/*.cson', () => {
+  const root = makeStorage()
+  const { storage, notes } = loadStorage(root, 'client')
+
+  assert.equal(storage.key, 'client')
+  assert.equal(storage.name, 'client')
+  assert.equal(storage.folders.length, 2)
+  assert.equal(storage.folders[0].name, 'AIM')
+
+  assert.equal(notes.length, 2) // README.txt ignored
+  const cls = notes.find(n => n.key === 'abc123')
+  assert.equal(cls.title, 'CLS 改善計画')
+  assert.equal(cls.type, 'MARKDOWN_NOTE')
+  assert.equal(cls.folder, 'aim')
+  assert.equal(cls.storage, 'client')
+  assert.equal(cls.isStarred, true)
+  assert.deepEqual(cls.tags, ['perf', 'seo'])
+  assert.ok(cls.content.startsWith('# CLS 改善計画'))
+
+  const snip = notes.find(n => n.key === 'def456')
+  assert.equal(snip.type, 'SNIPPET_NOTE')
+  assert.equal(snip.isStarred, false) // defaulted
+  assert.deepEqual(snip.tags, [])
+
+  fs.rmSync(root, { recursive: true, force: true })
+})
+
+test('loadStorages aggregates and skips non-storage roots', () => {
+  const a = makeStorage()
+  const b = makeStorage()
+  const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'bn-empty-'))
+  const { storages, notes } = loadStorages([a, b, empty, '/does/not/exist'])
+  assert.equal(storages.length, 2)
+  assert.equal(notes.length, 4)
+  fs.rmSync(a, { recursive: true, force: true })
+  fs.rmSync(b, { recursive: true, force: true })
+  fs.rmSync(empty, { recursive: true, force: true })
+})


### PR DESCRIPTION
モダンアプリを「実 `.cson` ノートを読む**実デスクトップアプリ**」にする土台。

## 内容
- **`electron/loadNotes.cjs`** — 純 Node リーダ: storage の `boostnote.json` + `notes/*.cson` → アプリの `Note` 形状。**ユニットテスト済み**（folder解釈・非cson除外・複数storage集約・デフォルト補完）。
- **`electron/main.cjs` + `preload.cjs`** — セキュアな Electron 42 シェル（contextIsolation / sandbox / nodeIntegration off）、IPC は `notes:load` の1本。`BOOSTNOTE_STORAGE`（path区切りの storage ルート群）を読む。
- **`src/data/repository.ts`** — `createRepository()` が Electron なら実リーダ、ブラウザなら in-memory サンプルを選択。App は無改修で利用。
- **CI**: `modern.yml` の app ジョブに `npm test` を追加、electron バイナリDLはスキップ（build/test に不要）。

## 検証
- Node 22 で renderer ビルド＋データ層テスト緑
- **Electron 42（arm64ネイティブ）でアプリが起動・描画**、実 `.cson` ストレージを指して app-code エラー0

GPL-3.0 継承。次: 共同編集（Yjs+Hocuspocus 結線）／検索・タグ／パッケージング（署名・auto-update）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)