### PR TITLE
fix(release): electron-builder の公開先を明示（DLリリース修正）

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,6 +3,13 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
+  "description": "Boostnote — modern, collaborative note app for programmers",
+  "author": "BoxPistols",
+  "license": "GPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BoxPistols/Boostnote.git"
+  },
   "main": "electron/main.cjs",
   "scripts": {
     "dev": "vite",
@@ -45,6 +52,12 @@
     "appId": "io.boxpistols.boostnote",
     "productName": "Boostnote",
     "copyright": "GPL-3.0, inherited from BoostIO",
+    "publish": {
+      "provider": "github",
+      "owner": "BoxPistols",
+      "repo": "Boostnote",
+      "releaseType": "release"
+    },
     "files": [
       "dist/**",
       "electron/**",


### PR DESCRIPTION
`app-v0.1.0` の release ワークフローが **`⨯ Cannot detect repository by .git/config`** で失敗（mac/win 両方）。SSH remote から公開先を推測できないのが原因。

修正: `app/package.json` に公開先を明示。
- `repository`（https URL）、`description`/`author`/`license`（警告解消）
- `build.publish = { provider: github, owner: BoxPistols, repo: Boostnote, releaseType: release }` → GitHub Releases へ直接公開（即DL可能）

マージ後に release ワークフローを再実行して `v0.1.0` リリース（DLリンク）を生成します。