### PR TITLE
app: 改名「The Boosters」+ macOS universal + 未署名起動手順

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -1,8 +1,9 @@
-# app — modern Boostnote shell (foundation)
+# The Boosters — modern app (foundation)
 
-The modernized app foundation: **Vite + React 19 + TypeScript + CodeMirror 6**,
-reproducing the current Boostnote UI/UX (3-pane: sidebar / note list / split
-editor + live preview, dark theme) on a fast, stable, extensible base.
+**The Boosters** is the renamed successor to the discontinued Boostnote. This is
+its modern app foundation: **Vite + React 19 + TypeScript + CodeMirror 6**,
+reproducing Boostnote's UI/UX (3-pane: sidebar / note list / split editor + live
+preview, dark theme) on a fast, stable, extensible base.
 
 Direction (confirmed with the user): **inherit the current UX but evolve it**,
 and **prioritize a fast, stable foundation first** before new features. Inherits

--- a/app/index.html
+++ b/app/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>app</title>
+    <title>The Boosters</title>
   </head>
   <body>
     <div id="root"></div>

--- a/app/package.json
+++ b/app/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "app",
+  "name": "the-boosters",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
-  "description": "Boostnote — modern, collaborative note app for programmers",
+  "description": "The Boosters — a modern, collaborative note app for programmers (successor to the discontinued Boostnote)",
   "author": "BoxPistols",
   "license": "GPL-3.0",
   "repository": {
@@ -49,9 +49,9 @@
     "vite": "^8.1.0"
   },
   "build": {
-    "appId": "io.boxpistols.boostnote",
-    "productName": "Boostnote",
-    "copyright": "GPL-3.0, inherited from BoostIO",
+    "appId": "io.boxpistols.theboosters",
+    "productName": "The Boosters",
+    "copyright": "GPL-3.0, inherited from BoostIO (Boostnote)",
     "publish": {
       "provider": "github",
       "owner": "BoxPistols",
@@ -68,8 +68,18 @@
     },
     "mac": {
       "target": [
-        "dmg",
-        "zip"
+        {
+          "target": "dmg",
+          "arch": [
+            "universal"
+          ]
+        },
+        {
+          "target": "zip",
+          "arch": [
+            "universal"
+          ]
+        }
       ],
       "category": "public.app-category.productivity"
     },

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
-<h1 align="center">Boostnote（BoxPistols フォーク）</h1>
+<h1 align="center">The Boosters</h1>
 
-<h4 align="center">プログラマ向けノートアプリ Boostnote Legacy を、UI/UX を引き継ぎつつ最新スタックへモダン化中。</h4>
+<h4 align="center">プログラマ向けノートアプリ Boostnote Legacy の後継。UI/UX を引き継ぎつつ、リアルタイム共同編集・local-first・拡張性を備えた最新スタックへ。</h4>
+<h5 align="center">※ Boostnote はサービス終了済みのため、敬意を込めて「The Boosters」へ改名（GPL-3.0 継承）。</h5>
 
 <p align="center">
   <a href="https://github.com/BoxPistols/Boostnote/actions/workflows/ci.yml">
@@ -57,8 +58,15 @@ cd poc/collab-core && npm install && npm test
 git tag app-v0.1.0 && git push origin app-v0.1.0
 ```
 
-> ⚠️ 現状の配布ビルドは **未署名**（署名証明書未設定）のため、初回起動時に macOS / Windows の警告が出ます。
-> Apple Developer ID / Windows コード署名証明書を Secrets に追加して `release.yml` に配線すれば、署名・notarize 済みで配布できます。
+> ⚠️ 現状の配布ビルドは **未署名**（署名証明書未設定）のため、初回起動時に OS の警告が出ます。
+>
+> **macOS で「壊れているため開けません」と出る場合**（未署名＋ダウンロード隔離属性が原因）— アプリを `/Applications` 等へ移動してから、ターミナルで隔離属性を外すと起動できます:
+> ```bash
+> xattr -dr com.apple.quarantine "/Applications/The Boosters.app"
+> ```
+> **Windows** は SmartScreen の「詳細情報」→「実行」で起動できます。
+>
+> 恒久対応は **Apple Developer ID / Windows コード署名証明書**を GitHub Secrets に登録 → `release.yml` に配線して、署名・notarize 済み（警告なし）で配布します。
 
 レガシー本家ビルドは [BoostIO/boost-releases](https://github.com/BoostIO/boost-releases/releases/) から入手できます。
 


### PR DESCRIPTION
## 改名: The Boosters
Boostnote は終了済みのため、敬意を残しつつ製品名を **The Boosters** に改名（ユーザー確定）。
- `productName` → "The Boosters"、`appId` → `io.boxpistols.theboosters`、package `name` → `the-boosters`、`index.html` title、README（ルート/app）更新。GPL-3.0 継承。

## 配布の堅牢化
- macOS を **universal(Intel+ARM)** ビルドに（`mac.target` の arch を `["universal"]`）。これまで arm64 のみ→全 Mac 対象。`version` 0.1.1。
- ルート README のDL節に **未署名アプリの起動手順**を追記（macOS の「壊れているため開けません」= `xattr -dr com.apple.quarantine`、Windows SmartScreen 回避）。

## 検証
renderer ビルド + データ層テスト緑。マージ後 `app-v0.1.1` タグで universal インストーラを再リリースします。

> 恒久的に警告を消すには Apple Developer ID / Windows 証明書を Secrets 登録 → `release.yml` 配線が必要。