### PR TITLE
app: 実ノート読込（ストレージフォルダピッカー）

### DIFF
--- a/app/electron/main.cjs
+++ b/app/electron/main.cjs
@@ -1,27 +1,77 @@
 'use strict'
 
-// Minimal, secure Electron shell for the modern app. Loads the Vite-built
-// renderer and bridges a single IPC channel that reads the user's real
-// `.cson` storages from disk (BOOSTNOTE_STORAGE = path-separated storage roots).
+// Secure Electron shell for The Boosters. Loads the Vite-built renderer and
+// bridges two IPC channels:
+//   notes:load        -> read the configured + env .cson storages
+//   notes:pickStorage -> let the user pick a storage folder (persisted)
 //
-//   npm run build && BOOSTNOTE_STORAGE=/path/to/storage npm run electron
+// Storage roots come from a persisted config (userData/config.json) and/or the
+// BOOSTNOTE_STORAGE env var (path-separated). A "storage" is a folder with a
+// boostnote.json + notes/*.cson.
 
-const { app, BrowserWindow, ipcMain } = require('electron')
+const { app, BrowserWindow, ipcMain, dialog } = require('electron')
+const fs = require('node:fs')
 const path = require('node:path')
 const { loadStorages } = require('./loadNotes.cjs')
 
-function storageRoots() {
+const configPath = () => path.join(app.getPath('userData'), 'config.json')
+
+function readConfig() {
+  try {
+    return JSON.parse(fs.readFileSync(configPath(), 'utf8'))
+  } catch {
+    return { storageRoots: [] }
+  }
+}
+
+function writeConfig(config) {
+  fs.mkdirSync(path.dirname(configPath()), { recursive: true })
+  fs.writeFileSync(configPath(), JSON.stringify(config, null, 2))
+}
+
+function envRoots() {
   const raw = process.env.BOOSTNOTE_STORAGE
   return raw ? raw.split(path.delimiter).filter(Boolean) : []
 }
 
-ipcMain.handle('notes:load', () => {
+function allRoots() {
+  const fromConfig = readConfig().storageRoots || []
+  return [...new Set([...fromConfig, ...envRoots()])]
+}
+
+function load() {
   try {
-    return loadStorages(storageRoots())
+    return loadStorages(allRoots())
   } catch (err) {
     console.error('notes:load failed:', err)
     return { storages: [], notes: [], error: String(err) }
   }
+}
+
+ipcMain.handle('notes:load', () => load())
+
+// Let the user pick a Boostnote storage folder; persist it and return notes.
+ipcMain.handle('notes:pickStorage', async () => {
+  const res = await dialog.showOpenDialog({
+    title: 'Boostnote ストレージフォルダを選択（boostnote.json があるフォルダ）',
+    properties: ['openDirectory', 'createDirectory']
+  })
+  if (res.canceled || res.filePaths.length === 0) return null
+
+  const picked = res.filePaths[0]
+  if (!fs.existsSync(path.join(picked, 'boostnote.json'))) {
+    return {
+      storages: [],
+      notes: [],
+      error: '選択したフォルダに boostnote.json が見つかりません。'
+    }
+  }
+
+  const config = readConfig()
+  const roots = new Set(config.storageRoots || [])
+  roots.add(picked)
+  writeConfig({ ...config, storageRoots: [...roots] })
+  return load()
 })
 
 function createWindow() {

--- a/app/electron/preload.cjs
+++ b/app/electron/preload.cjs
@@ -6,5 +6,6 @@
 const { contextBridge, ipcRenderer } = require('electron')
 
 contextBridge.exposeInMainWorld('boostnote', {
-  loadNotes: () => ipcRenderer.invoke('notes:load')
+  loadNotes: () => ipcRenderer.invoke('notes:load'),
+  pickStorage: () => ipcRenderer.invoke('notes:pickStorage')
 })

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -23,6 +23,24 @@ export default function App() {
     value: 'all'
   })
   const [activeKey, setActiveKey] = useState<string | null>(null)
+  const [pickError, setPickError] = useState<string | null>(null)
+
+  const canPick = typeof repository.pickStorage === 'function'
+
+  async function handlePickStorage() {
+    if (!repository.pickStorage) return
+    try {
+      setPickError(null)
+      const res = await repository.pickStorage()
+      if (!res) return
+      setStorages(res.storages)
+      setNotes(res.notes)
+      setSelection({ kind: 'smart', value: 'all' })
+      setActiveKey(res.notes[0]?.key ?? null)
+    } catch (e) {
+      setPickError(e instanceof Error ? e.message : String(e))
+    }
+  }
 
   useEffect(() => {
     let alive = true
@@ -105,6 +123,7 @@ export default function App() {
         notes={notes}
         selection={selection}
         onSelect={selectView}
+        onPickStorage={canPick ? handlePickStorage : undefined}
       />
       <NoteList notes={visible} activeKey={activeKey} onSelect={setActiveKey} />
       {active ? (
@@ -133,7 +152,29 @@ export default function App() {
           </div>
         </section>
       ) : (
-        <div className="empty">Select a note</div>
+        <div className="empty">
+          {notes.length === 0 && canPick ? (
+            <div style={{ textAlign: 'center', maxWidth: 360 }}>
+              <div style={{ fontSize: 15, color: 'var(--fg)', marginBottom: 6 }}>
+                ノートがありません
+              </div>
+              <div style={{ marginBottom: 14 }}>
+                Boostnote のストレージフォルダ（<code>boostnote.json</code> が
+                あるフォルダ）を開くと、ノートが読み込まれます。
+              </div>
+              <button className="btn-primary" onClick={handlePickStorage}>
+                📂 ストレージフォルダを開く
+              </button>
+              {pickError && (
+                <div style={{ color: 'var(--accent)', marginTop: 10 }}>
+                  {pickError}
+                </div>
+              )}
+            </div>
+          ) : (
+            'Select a note'
+          )}
+        </div>
       )}
     </div>
   )

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -5,9 +5,17 @@ interface Props {
   notes: Note[]
   selection: Selection
   onSelect: (s: Selection) => void
+  /** When set (Electron), shows a button to add a real storage folder. */
+  onPickStorage?: () => void
 }
 
-export function Sidebar({ storages, notes, selection, onSelect }: Props) {
+export function Sidebar({
+  storages,
+  notes,
+  selection,
+  onSelect,
+  onPickStorage
+}: Props) {
   const live = notes.filter(n => !n.isTrashed)
   const counts = {
     all: live.length,
@@ -81,6 +89,14 @@ export function Sidebar({ storages, notes, selection, onSelect }: Props) {
               </span>
             ))}
           </div>
+        </div>
+      )}
+
+      {onPickStorage && (
+        <div className="side-section" style={{ marginTop: 'auto' }}>
+          <button className="btn-ghost" onClick={onPickStorage}>
+            ＋ ストレージを追加
+          </button>
         </div>
       )}
     </nav>

--- a/app/src/data/repository.ts
+++ b/app/src/data/repository.ts
@@ -9,6 +9,8 @@ import { sampleNotes, sampleStorages } from './sampleNotes'
  */
 export interface NotesRepository {
   load(): Promise<{ storages: Storage[]; notes: Note[] }>
+  /** Present only when the runtime can pick a real storage folder (Electron). */
+  pickStorage?(): Promise<{ storages: Storage[]; notes: Note[] } | null>
 }
 
 // Deterministic (no Math.random) generator so the list reaches realistic
@@ -66,6 +68,12 @@ export function createElectronRepository(): NotesRepository {
   return {
     async load() {
       const res = await window.boostnote!.loadNotes()
+      return { storages: res.storages, notes: res.notes }
+    },
+    async pickStorage() {
+      const res = await window.boostnote!.pickStorage()
+      if (!res) return null
+      if (res.error) throw new Error(res.error)
       return { storages: res.storages, notes: res.notes }
     }
   }

--- a/app/src/electron.d.ts
+++ b/app/src/electron.d.ts
@@ -1,15 +1,18 @@
 import type { Note, Storage } from './types'
 
+export interface LoadResult {
+  storages: Storage[]
+  notes: Note[]
+  error?: string
+}
+
 // The preload bridge (electron/preload.cjs). Present only when running inside
 // Electron; the browser foundation falls back to the in-memory repository.
 declare global {
   interface Window {
     boostnote?: {
-      loadNotes(): Promise<{
-        storages: Storage[]
-        notes: Note[]
-        error?: string
-      }>
+      loadNotes(): Promise<LoadResult>
+      pickStorage(): Promise<LoadResult | null>
     }
   }
 }

--- a/app/src/theme.css
+++ b/app/src/theme.css
@@ -108,4 +108,17 @@ body {
 .preview th, .preview td { border: 1px solid var(--border); padding: 4px 10px; }
 .preview blockquote { border-left: 3px solid var(--border); margin: 0; padding-left: 12px; color: var(--muted); }
 
-.empty { display: grid; place-items: center; height: 100%; color: var(--faint); }
+.empty { display: grid; place-items: center; height: 100%; color: var(--muted); padding: 24px; }
+.empty code { background: var(--bg-elev); padding: 1px 5px; border-radius: 4px; }
+
+.btn-primary, .btn-ghost {
+  font: inherit;
+  cursor: pointer;
+  border-radius: var(--radius);
+  padding: 8px 14px;
+  border: 1px solid var(--border);
+}
+.btn-primary { background: var(--accent); color: #fff; border-color: transparent; }
+.btn-primary:hover { filter: brightness(1.08); }
+.btn-ghost { background: transparent; color: var(--muted); width: 100%; }
+.btn-ghost:hover { background: #2a2e36; color: var(--fg); }


### PR DESCRIPTION
## 概要
パッケージ版（ダブルクリック起動）は `BOOSTNOTE_STORAGE` 環境変数を持たないため、実際のノートを読み込めなかった。アプリ内からストレージフォルダ（`boostnote.json` があるフォルダ）を選んで読み込めるようにする。

## 変更点
- **main.cjs**: `userData/config.json` に `storageRoots` を永続化。`notes:pickStorage` IPC でフォルダ選択ダイアログ → `boostnote.json` 検証 → 保存 → 再読込。`allRoots()` で config と `BOOSTNOTE_STORAGE` を統合（重複排除）。
- **preload.cjs**: `pickStorage` を `contextBridge` に追加（最小公開面を維持）。
- **repository.ts**: `NotesRepository` に任意の `pickStorage?()` を追加。Electron 実装で `res.error` を throw して UI に伝播。
- **App.tsx**: 空状態に「📂 ストレージフォルダを開く」ボタン、サイドバー下部に「＋ ストレージを追加」。エラーは画面に表示。
- **electron.d.ts / theme.css**: 型（`LoadResult` / `pickStorage`）とボタンスタイルを追加。

## セキュリティ
`contextIsolation: true` / `nodeIntegration: false` / `sandbox: true` を維持。レンダラには `window.boostnote` の2メソッドのみ公開。

## 検証
- `npm run lint` / `npm run build` / `npm test`（2 pass）すべて緑
- `config → allRoots → loadStorages` の結合をスモークテストで確認（synthetic storage で notes 読込 OK）

🤖 Generated with [Claude Code](https://claude.com/claude-code)