### PR TITLE
app: 全文検索（タイトル/本文/タグ・AND 絞り込み）

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "test": "node --test test/*.test.mjs",
+    "test": "node --experimental-strip-types --test test/*.test.mjs",
     "lint": "oxlint",
     "preview": "vite preview",
     "electron": "electron .",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { Note, Selection, Storage } from './types'
 import { createRepository } from './data/repository'
+import { filterByQuery } from './data/search'
 import { Sidebar } from './components/Sidebar'
 import { NoteList } from './components/NoteList'
 import { MarkdownEditor } from './components/MarkdownEditor'
@@ -24,6 +25,7 @@ export default function App() {
   })
   const [activeKey, setActiveKey] = useState<string | null>(null)
   const [pickError, setPickError] = useState<string | null>(null)
+  const [query, setQuery] = useState('')
 
   const canPick = typeof repository.pickStorage === 'function'
 
@@ -57,19 +59,25 @@ export default function App() {
 
   const visible = useMemo(() => {
     const live = notes.filter(n => !n.isTrashed)
+    let base: Note[] = live
     switch (selection.kind) {
       case 'smart':
-        if (selection.value === 'starred') return live.filter(n => n.isStarred)
-        if (selection.value === 'trashed') return notes.filter(n => n.isTrashed)
-        return live
+        if (selection.value === 'starred') base = live.filter(n => n.isStarred)
+        else if (selection.value === 'trashed')
+          base = notes.filter(n => n.isTrashed)
+        break
       case 'folder': {
         const [storage, folder] = selection.value.split('|')
-        return live.filter(n => n.storage === storage && n.folder === folder)
+        base = live.filter(n => n.storage === storage && n.folder === folder)
+        break
       }
       case 'tag':
-        return live.filter(n => n.tags.includes(selection.value))
+        base = live.filter(n => n.tags.includes(selection.value))
+        break
     }
-  }, [notes, selection])
+    // Refine the current view by the search query (AND across terms).
+    return filterByQuery(base, query)
+  }, [notes, selection, query])
 
   const active = notes.find(n => n.key === activeKey) ?? null
 
@@ -125,7 +133,13 @@ export default function App() {
         onSelect={selectView}
         onPickStorage={canPick ? handlePickStorage : undefined}
       />
-      <NoteList notes={visible} activeKey={activeKey} onSelect={setActiveKey} />
+      <NoteList
+        notes={visible}
+        activeKey={activeKey}
+        onSelect={setActiveKey}
+        query={query}
+        onQueryChange={setQuery}
+      />
       {active ? (
         <section className="detail">
           <div className="detail-head">

--- a/app/src/components/NoteList.tsx
+++ b/app/src/components/NoteList.tsx
@@ -5,6 +5,8 @@ interface Props {
   notes: Note[]
   activeKey: string | null
   onSelect: (key: string) => void
+  query: string
+  onQueryChange: (q: string) => void
 }
 
 const ROW_H = 58 // fixed row height enables simple, fast windowing
@@ -19,7 +21,13 @@ function shortDate(iso: string) {
  * Virtualized note list: only the rows in (and just around) the viewport are
  * rendered, so hundreds of notes scroll smoothly. Sorted by Updated desc.
  */
-export function NoteList({ notes, activeKey, onSelect }: Props) {
+export function NoteList({
+  notes,
+  activeKey,
+  onSelect,
+  query,
+  onQueryChange
+}: Props) {
   const sorted = useMemo(
     () =>
       [...notes].sort((a, b) => +new Date(b.updatedAt) - +new Date(a.updatedAt)),
@@ -27,8 +35,22 @@ export function NoteList({ notes, activeKey, onSelect }: Props) {
   )
 
   const scrollRef = useRef<HTMLDivElement>(null)
+  const searchRef = useRef<HTMLInputElement>(null)
   const [scrollTop, setScrollTop] = useState(0)
   const [viewport, setViewport] = useState(800)
+
+  // Cmd/Ctrl+F focuses the search box (no native browser find in Electron).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
+        e.preventDefault()
+        searchRef.current?.focus()
+        searchRef.current?.select()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [])
 
   useEffect(() => {
     const el = scrollRef.current
@@ -47,6 +69,16 @@ export function NoteList({ notes, activeKey, onSelect }: Props) {
 
   return (
     <section className="notelist">
+      <div className="notelist-search">
+        <input
+          ref={searchRef}
+          className="search-input"
+          type="search"
+          placeholder="検索…  (⌘/Ctrl+F)"
+          value={query}
+          onChange={e => onQueryChange(e.target.value)}
+        />
+      </div>
       <div className="notelist-head">
         <span>⌄ Updated</span>
         <span className="sort" style={{ marginLeft: 'auto' }}>
@@ -89,7 +121,9 @@ export function NoteList({ notes, activeKey, onSelect }: Props) {
             )
           })}
           {total === 0 && (
-            <div style={{ padding: 20, color: 'var(--faint)' }}>No notes</div>
+            <div style={{ padding: 20, color: 'var(--faint)' }}>
+              {query.trim() ? '一致するノートがありません' : 'No notes'}
+            </div>
           )}
         </div>
       </div>

--- a/app/src/data/search.ts
+++ b/app/src/data/search.ts
@@ -1,0 +1,26 @@
+import type { Note } from '../types'
+
+/**
+ * Full-text search over notes. A query is split into whitespace-separated
+ * terms that are combined with AND (every term must appear), matched
+ * case-insensitively across each note's title, content and tags.
+ */
+
+/** Split a raw query into lowercased AND-terms (whitespace separated). */
+export function queryTerms(query: string): string[] {
+  return query.trim().toLowerCase().split(/\s+/).filter(Boolean)
+}
+
+/** True when the note contains every term across title, content and tags. */
+export function noteMatches(note: Note, terms: string[]): boolean {
+  if (terms.length === 0) return true
+  const hay = `${note.title}\n${note.content}\n${note.tags.join(' ')}`.toLowerCase()
+  return terms.every(term => hay.includes(term))
+}
+
+/** Filter notes by a raw query string; empty query returns the input as-is. */
+export function filterByQuery(notes: Note[], query: string): Note[] {
+  const terms = queryTerms(query)
+  if (terms.length === 0) return notes
+  return notes.filter(note => noteMatches(note, terms))
+}

--- a/app/src/theme.css
+++ b/app/src/theme.css
@@ -61,6 +61,14 @@ body {
 
 /* ---- Note list -------------------------------------------------------- */
 .notelist { background: var(--bg-list); border-right: 1px solid var(--border); display: flex; flex-direction: column; min-width: 0; }
+.notelist-search { padding: 8px 10px; border-bottom: 1px solid var(--border); }
+.search-input {
+  width: 100%; font: inherit; color: var(--fg);
+  background: var(--bg-elev); border: 1px solid var(--border);
+  border-radius: var(--radius); padding: 6px 10px;
+}
+.search-input::placeholder { color: var(--faint); }
+.search-input:focus { outline: none; border-color: var(--accent); }
 .notelist-head {
   display: flex; align-items: center; gap: 8px;
   padding: 10px 14px; border-bottom: 1px solid var(--border); color: var(--muted);

--- a/app/test/search.test.mjs
+++ b/app/test/search.test.mjs
@@ -1,0 +1,60 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { queryTerms, noteMatches, filterByQuery } from '../src/data/search.ts'
+
+const note = (over) => ({
+  key: 'k',
+  type: 'MARKDOWN_NOTE',
+  title: 'Hello World',
+  content: '# Hello\n\nThe quick brown fox',
+  tags: ['draft', 'fox'],
+  storage: 's',
+  folder: 'f',
+  isStarred: false,
+  isTrashed: false,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  ...over
+})
+
+test('queryTerms splits, lowercases and drops blanks', () => {
+  assert.deepEqual(queryTerms('  Quick   Brown '), ['quick', 'brown'])
+  assert.deepEqual(queryTerms(''), [])
+  assert.deepEqual(queryTerms('   '), [])
+})
+
+test('noteMatches: empty terms always match', () => {
+  assert.equal(noteMatches(note(), []), true)
+})
+
+test('noteMatches matches across title, content and tags', () => {
+  // Terms are pre-lowercased by queryTerms; noteMatches lowercases the haystack.
+  assert.equal(noteMatches(note(), ['hello']), true) // title
+  assert.equal(noteMatches(note(), ['brown']), true) // content
+  assert.equal(noteMatches(note(), ['draft']), true) // tag
+})
+
+test('filterByQuery is case-insensitive (via queryTerms)', () => {
+  assert.equal(filterByQuery([note()], 'HELLO').length, 1)
+  assert.equal(filterByQuery([note()], 'Brown Fox').length, 1)
+})
+
+test('noteMatches requires every term (AND)', () => {
+  assert.equal(noteMatches(note(), ['hello', 'fox']), true)
+  assert.equal(noteMatches(note(), ['hello', 'missing']), false)
+})
+
+test('filterByQuery returns input unchanged for blank query', () => {
+  const notes = [note({ key: 'a' }), note({ key: 'b' })]
+  assert.equal(filterByQuery(notes, '   '), notes)
+})
+
+test('filterByQuery keeps only matching notes', () => {
+  const notes = [
+    note({ key: 'a', title: 'Apple pie' }),
+    note({ key: 'b', title: 'Banana split', content: '', tags: [] })
+  ]
+  const got = filterByQuery(notes, 'banana')
+  assert.equal(got.length, 1)
+  assert.equal(got[0].key, 'b')
+})


### PR DESCRIPTION
## 概要
ノート一覧の上部に検索ボックスを追加。空白区切りの各語を **AND** でタイトル・本文・タグに対し大文字小文字を無視してマッチさせ、現在のビュー（フォルダ / タグ / スマート選択）を絞り込む。

## 変更点
- **data/search.ts（新規）**: `queryTerms` / `noteMatches` / `filterByQuery` の純関数。検索ロジックを UI から分離し単体テスト可能に。
- **App.tsx**: `query` state を追加、`visible` メモで `filterByQuery` と選択を合成。
- **NoteList.tsx**: ヘッダに検索 `input`、**⌘/Ctrl+F** でフォーカス（Electron にネイティブ検索がないため）、0 件時は「一致するノートがありません」を表示。
- **theme.css**: `.notelist-search` / `.search-input` スタイル。
- **test/search.test.mjs（新規）**: 純関数の単体テスト（7 ケース、AND・大文字小文字・タグ横断を網羅）。
- **package.json**: `test` を `--experimental-strip-types` 付きにし、TS ソースを直接テスト可能に（Node 22.6+）。モダンアプリ初のレンダラ層ユニットテスト。

## 設計メモ
- 検索は現在の選択ビューを**絞り込む**（全体横断ではない）。全ノート検索は「All Notes」を選んでから。予測可能で実装も単純。
- `noteMatches` の語は呼び出し側（`queryTerms`）で小文字化する契約。大文字小文字無視は `filterByQuery` 経由でテスト。

## 検証
`npm run lint` / `npm run build` / `npm test`（**9 pass**: loadNotes 2 + search 7）すべて緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)