### PR TITLE
app: ノート編集の .cson 書き戻し（オートセーブ永続化）

### DIFF
--- a/app/electron/loadNotes.cjs
+++ b/app/electron/loadNotes.cjs
@@ -60,6 +60,44 @@ function loadStorage(rootDir, storageKey) {
   return { storage, notes }
 }
 
+// Fields the renderer may change; everything else in the raw `.cson` (e.g. a
+// SNIPPET_NOTE's `snippets` array, or any unknown keys) is preserved untouched.
+const EDITABLE = ['title', 'content', 'tags', 'isStarred', 'isTrashed', 'updatedAt']
+
+/**
+ * Write an edited note back to its `.cson` file, preserving every field the
+ * renderer doesn't own. The file is located by `note.key` (its filename) under
+ * one of the known storage roots; the write is atomic (temp file + rename).
+ * @param {string[]} roots
+ * @param {object} note  Note shape ({ key, title, content, tags, ... })
+ * @returns {{ ok: boolean, file?: string, error?: string }}
+ */
+function saveNote(roots, note) {
+  const key = String((note && note.key) || '')
+  // Defense in depth: a key must be a bare filename, never a path.
+  if (!key || /[/\\]/.test(key) || key.includes('..')) {
+    return { ok: false, error: 'invalid note key' }
+  }
+  for (const root of roots) {
+    if (!root) continue
+    const notesDir = path.join(root, 'notes')
+    const file = path.join(notesDir, `${key}.cson`)
+    if (path.dirname(file) !== notesDir) continue // reject traversal
+    if (!fs.existsSync(file)) continue
+
+    const raw = CSON.parse(fs.readFileSync(file, 'utf8'))
+    const merged = { ...raw }
+    for (const f of EDITABLE) {
+      if (note[f] !== undefined) merged[f] = note[f]
+    }
+    const tmp = `${file}.tmp`
+    fs.writeFileSync(tmp, CSON.stringify(merged, null, 2))
+    fs.renameSync(tmp, file) // atomic replace
+    return { ok: true, file }
+  }
+  return { ok: false, error: `note "${key}" not found in any storage` }
+}
+
 /**
  * Load several storage roots and aggregate them.
  * @param {string[]} roots
@@ -77,4 +115,4 @@ function loadStorages(roots) {
   return { storages, notes }
 }
 
-module.exports = { loadStorage, loadStorages, toNote }
+module.exports = { loadStorage, loadStorages, toNote, saveNote }

--- a/app/electron/main.cjs
+++ b/app/electron/main.cjs
@@ -12,7 +12,7 @@
 const { app, BrowserWindow, ipcMain, dialog } = require('electron')
 const fs = require('node:fs')
 const path = require('node:path')
-const { loadStorages } = require('./loadNotes.cjs')
+const { loadStorages, saveNote } = require('./loadNotes.cjs')
 
 const configPath = () => path.join(app.getPath('userData'), 'config.json')
 
@@ -49,6 +49,16 @@ function load() {
 }
 
 ipcMain.handle('notes:load', () => load())
+
+// Persist an edited note back to its `.cson` file.
+ipcMain.handle('notes:save', (_event, note) => {
+  try {
+    return saveNote(allRoots(), note)
+  } catch (err) {
+    console.error('notes:save failed:', err)
+    return { ok: false, error: String(err) }
+  }
+})
 
 // Let the user pick a Boostnote storage folder; persist it and return notes.
 ipcMain.handle('notes:pickStorage', async () => {

--- a/app/electron/preload.cjs
+++ b/app/electron/preload.cjs
@@ -7,5 +7,6 @@ const { contextBridge, ipcRenderer } = require('electron')
 
 contextBridge.exposeInMainWorld('boostnote', {
   loadNotes: () => ipcRenderer.invoke('notes:load'),
-  pickStorage: () => ipcRenderer.invoke('notes:pickStorage')
+  pickStorage: () => ipcRenderer.invoke('notes:pickStorage'),
+  saveNote: note => ipcRenderer.invoke('notes:save', note)
 })

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type { Note, Selection, Storage } from './types'
 import { createRepository } from './data/repository'
 import { filterByQuery } from './data/search'
@@ -26,8 +26,26 @@ export default function App() {
   const [activeKey, setActiveKey] = useState<string | null>(null)
   const [pickError, setPickError] = useState<string | null>(null)
   const [query, setQuery] = useState('')
+  const [saveError, setSaveError] = useState<string | null>(null)
 
   const canPick = typeof repository.pickStorage === 'function'
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Persist a note; failures surface in the header rather than being swallowed.
+  function persist(note: Note) {
+    if (!repository.saveNote) return
+    repository.saveNote(note).then(
+      () => setSaveError(null),
+      e => setSaveError(e instanceof Error ? e.message : String(e))
+    )
+  }
+
+  // Debounced autosave for rapid edits (typing); coalesces to the latest note.
+  function scheduleSave(note: Note) {
+    if (!repository.saveNote) return
+    if (saveTimer.current) clearTimeout(saveTimer.current)
+    saveTimer.current = setTimeout(() => persist(note), 600)
+  }
 
   async function handlePickStorage() {
     if (!repository.pickStorage) return
@@ -95,27 +113,21 @@ export default function App() {
 
   function updateActiveContent(content: string) {
     if (!active) return
-    setNotes(prev =>
-      prev.map(n =>
-        n.key === active.key
-          ? {
-              ...n,
-              content,
-              title: firstTitle(content, n.title),
-              updatedAt: new Date().toISOString()
-            }
-          : n
-      )
-    )
+    const updated: Note = {
+      ...active,
+      content,
+      title: firstTitle(content, active.title),
+      updatedAt: new Date().toISOString()
+    }
+    setNotes(prev => prev.map(n => (n.key === updated.key ? updated : n)))
+    scheduleSave(updated) // debounced write-back
   }
 
   function toggleStar() {
     if (!active) return
-    setNotes(prev =>
-      prev.map(n =>
-        n.key === active.key ? { ...n, isStarred: !n.isStarred } : n
-      )
-    )
+    const updated: Note = { ...active, isStarred: !active.isStarred }
+    setNotes(prev => prev.map(n => (n.key === updated.key ? updated : n)))
+    persist(updated) // immediate write-back (single action)
   }
 
   const folderName = active
@@ -144,6 +156,11 @@ export default function App() {
         <section className="detail">
           <div className="detail-head">
             <span className="folder">📁 {folderName}</span>
+            {saveError && (
+              <span className="save-error" title={saveError}>
+                ⚠ 保存に失敗しました
+              </span>
+            )}
             <span className="spacer" />
             <span
               className={`star ${active.isStarred ? 'on' : ''}`}

--- a/app/src/data/repository.ts
+++ b/app/src/data/repository.ts
@@ -11,6 +11,8 @@ export interface NotesRepository {
   load(): Promise<{ storages: Storage[]; notes: Note[] }>
   /** Present only when the runtime can pick a real storage folder (Electron). */
   pickStorage?(): Promise<{ storages: Storage[]; notes: Note[] } | null>
+  /** Persist an edited note. Present only when notes are backed by real files. */
+  saveNote?(note: Note): Promise<void>
 }
 
 // Deterministic (no Math.random) generator so the list reaches realistic
@@ -75,6 +77,10 @@ export function createElectronRepository(): NotesRepository {
       if (!res) return null
       if (res.error) throw new Error(res.error)
       return { storages: res.storages, notes: res.notes }
+    },
+    async saveNote(note) {
+      const res = await window.boostnote!.saveNote(note)
+      if (!res.ok) throw new Error(res.error || 'note の保存に失敗しました')
     }
   }
 }

--- a/app/src/electron.d.ts
+++ b/app/src/electron.d.ts
@@ -6,6 +6,12 @@ export interface LoadResult {
   error?: string
 }
 
+export interface SaveResult {
+  ok: boolean
+  file?: string
+  error?: string
+}
+
 // The preload bridge (electron/preload.cjs). Present only when running inside
 // Electron; the browser foundation falls back to the in-memory repository.
 declare global {
@@ -13,6 +19,7 @@ declare global {
     boostnote?: {
       loadNotes(): Promise<LoadResult>
       pickStorage(): Promise<LoadResult | null>
+      saveNote(note: Note): Promise<SaveResult>
     }
   }
 }

--- a/app/src/theme.css
+++ b/app/src/theme.css
@@ -98,6 +98,7 @@ body {
 .detail-head .folder { color: var(--fg); font-weight: 600; }
 .detail-head .spacer { margin-left: auto; }
 .detail-head .star.on { color: var(--accent); }
+.detail-head .save-error { color: var(--accent); font-size: 12px; cursor: default; }
 .split { flex: 1; display: flex; min-height: 0; }
 .pane { flex: 1; min-width: 0; overflow: auto; }
 .pane.editor { border-right: 1px solid var(--border); }

--- a/app/test/saveNote.test.mjs
+++ b/app/test/saveNote.test.mjs
@@ -1,0 +1,90 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const CSON = require('cson-parser')
+const { saveNote, loadStorage } = require('../electron/loadNotes.cjs')
+
+function makeStorage(rawNote) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bn-save-'))
+  fs.writeFileSync(
+    path.join(root, 'boostnote.json'),
+    JSON.stringify({ name: 'S', folders: [{ key: 'f1', name: 'Inbox' }] })
+  )
+  fs.mkdirSync(path.join(root, 'notes'))
+  fs.writeFileSync(path.join(root, 'notes', 'n1.cson'), CSON.stringify(rawNote, null, 2))
+  return root
+}
+
+test('saveNote updates editable fields and preserves the rest', () => {
+  const root = makeStorage({
+    type: 'MARKDOWN_NOTE',
+    folder: 'f1',
+    title: 'Old',
+    content: 'old body',
+    tags: ['a'],
+    isStarred: false,
+    isTrashed: false,
+    createdAt: '2025-01-01T00:00:00.000Z',
+    updatedAt: '2025-01-01T00:00:00.000Z',
+    linesHighlighted: [1, 2] // unknown field the renderer doesn't own
+  })
+
+  const res = saveNote([root], {
+    key: 'n1',
+    title: 'New',
+    content: 'new body',
+    tags: ['a', 'b'],
+    isStarred: true,
+    isTrashed: false,
+    updatedAt: '2026-06-28T00:00:00.000Z'
+  })
+  assert.equal(res.ok, true)
+
+  const raw = CSON.parse(fs.readFileSync(path.join(root, 'notes', 'n1.cson'), 'utf8'))
+  assert.equal(raw.title, 'New')
+  assert.equal(raw.content, 'new body')
+  assert.deepEqual(raw.tags, ['a', 'b'])
+  assert.equal(raw.isStarred, true)
+  assert.equal(raw.updatedAt, '2026-06-28T00:00:00.000Z')
+  // preserved, untouched
+  assert.equal(raw.createdAt, '2025-01-01T00:00:00.000Z')
+  assert.deepEqual(raw.linesHighlighted, [1, 2])
+  assert.equal(raw.folder, 'f1')
+
+  // and it round-trips back through the loader
+  const { notes } = loadStorage(root)
+  assert.equal(notes[0].content, 'new body')
+  assert.equal(notes[0].isStarred, true)
+
+  fs.rmSync(root, { recursive: true, force: true })
+})
+
+test('saveNote leaves no temp file behind (atomic)', () => {
+  const root = makeStorage({ type: 'MARKDOWN_NOTE', content: 'x', createdAt: '2025-01-01' })
+  saveNote([root], { key: 'n1', content: 'y' })
+  const files = fs.readdirSync(path.join(root, 'notes'))
+  assert.deepEqual(files, ['n1.cson'])
+  fs.rmSync(root, { recursive: true, force: true })
+})
+
+test('saveNote rejects keys with path separators or traversal', () => {
+  const root = makeStorage({ type: 'MARKDOWN_NOTE', content: 'x' })
+  for (const bad of ['../secret', 'a/b', '..\\x', '']) {
+    const res = saveNote([root], { key: bad, content: 'z' })
+    assert.equal(res.ok, false)
+  }
+  fs.rmSync(root, { recursive: true, force: true })
+})
+
+test('saveNote returns ok:false when the note is in no storage', () => {
+  const root = makeStorage({ type: 'MARKDOWN_NOTE', content: 'x' })
+  const res = saveNote([root], { key: 'missing', content: 'z' })
+  assert.equal(res.ok, false)
+  assert.match(res.error, /not found/)
+  fs.rmSync(root, { recursive: true, force: true })
+})

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@
 | パス | 内容 | ランタイム |
 |---|---|---|
 | `browser/`, `lib/` | **レガシー本体**（Electron 4 + React 16 + Redux + webpack 1、`.cson` ファイル保存）。保守モードで安定化中 | Node 14 |
-| `app/` | **モダンアプリ土台**（Vite + React 19 + TypeScript + CodeMirror 6）。3ペインUXを再現、実 `.cson` を Electron 42 で読込 | Node 22 |
+| `app/` | **モダンアプリ土台**（Vite + React 19 + TypeScript + CodeMirror 6）。3ペインUXを再現し、実 `.cson` の読込・編集の書き戻し保存（オートセーブ）・全文検索・仮想化リスト・フォルダピッカーに対応。Electron 42 で配布 | Node 22 |
 | `poc/collab-core/` | **共同編集コアの実証**（Yjs + CodeMirror 6 + self-host Hocuspocus + `.cson` スナップショット、device-pairing 認証） | Node 22 |
 | `docs/` | モダナイゼーション設計判断書（スタック選定・脅威モデル・移行ロードマップ、事実検証済み） | — |
 | `.claude/skills/boostnote-modernize` | アーキテクチャ判断・作業方針をまとめた Claude Code スキル | — |


### PR DESCRIPTION
## 概要
これまでモダンアプリは**読み取り専用**で、編集はメモリ上だけ・再起動で失われていた。実 `.cson` ストレージへ編集を**書き戻して永続化**する（オートセーブ）。

## 変更点
- **loadNotes.cjs**: `saveNote(roots, note)` を追加。既存 raw を読み、**編集可能フィールドのみ**（`title` / `content` / `tags` / `isStarred` / `isTrashed` / `updatedAt`）上書きし、他フィールド（`createdAt`・SNIPPET の `snippets` 等の未知キー）は**温存**。`temp + rename` で**アトミック書き込み**。`key` はパス区切り / `..` を**拒否**しトラバーサルを防止。
- **main.cjs**: `notes:save` IPC（`allRoots()` からファイルを解決）。
- **preload.cjs / electron.d.ts**: `saveNote` を contextBridge と型（`SaveResult`）に追加。
- **repository.ts**: `NotesRepository.saveNote`（任意）。Electron 実装は `ok:false` を throw。ブラウザ土台では未提供＝**no-op**。
- **App.tsx**: 入力は **600ms デバウンス**で保存、★トグルは**即時保存**。失敗はヘッダに「⚠ 保存に失敗しました」を表示（**握りつぶさない**）。
- **test/saveNote.test.mjs（新規）**: round-trip・フィールド温存・アトミック性（temp 残らない）・トラバーサル拒否・未検出を網羅（4 ケース、合成ストレージのみ）。
- **readme.md**: モダンアプリの対応機能を更新。

## セキュリティ / 安全性
- 書き込み先は `allRoots()` 内の既存 `.cson` のみ。`path.dirname(file) === notesDir` を検証しトラバーサルを遮断。
- 既存フィールドを温存するマージ方式のため、SNIPPET ノートや未知メタデータを破壊しない。
- アトミック書き込みで途中失敗による破損を回避。

## 検証
`npm run lint` / `npm run build` / `npm test`（**13 pass**: loadNotes 2 + search 7 + saveNote 4）すべて緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)