### PR TITLE
app: 新規ノート作成・ゴミ箱（移動/復元/完全削除）で CRUD を完成

### DIFF
--- a/app/electron/loadNotes.cjs
+++ b/app/electron/loadNotes.cjs
@@ -7,6 +7,7 @@
 
 const fs = require('node:fs')
 const path = require('node:path')
+const crypto = require('node:crypto')
 const CSON = require('cson-parser')
 
 function readJson(file) {
@@ -99,6 +100,74 @@ function saveNote(roots, note) {
 }
 
 /**
+ * Create a new empty MARKDOWN note in a storage (matched by `opts.storage`,
+ * falling back to the first valid root) and return it in the Note shape.
+ * @param {string[]} roots
+ * @param {{ storage?: string, folder?: string, content?: string }} [opts]
+ * @returns {{ ok: boolean, note?: object, error?: string }}
+ */
+function createNote(roots, opts) {
+  const want = (opts && opts.storage) || ''
+  let root = null
+  let storageKey = ''
+  for (const r of roots) {
+    if (!r || !fs.existsSync(path.join(r, 'boostnote.json'))) continue
+    if (!root) {
+      root = r // first valid root is the fallback
+      storageKey = path.basename(r)
+    }
+    if (path.basename(r) === want) {
+      root = r
+      storageKey = want
+      break
+    }
+  }
+  if (!root) return { ok: false, error: 'no storage available' }
+
+  const notesDir = path.join(root, 'notes')
+  fs.mkdirSync(notesDir, { recursive: true })
+  const key = crypto.randomUUID().replace(/-/g, '')
+  const now = new Date().toISOString()
+  const raw = {
+    type: 'MARKDOWN_NOTE',
+    folder: (opts && opts.folder) || '',
+    title: '',
+    content: (opts && opts.content) || '',
+    tags: [],
+    isStarred: false,
+    isTrashed: false,
+    createdAt: now,
+    updatedAt: now
+  }
+  fs.writeFileSync(path.join(notesDir, `${key}.cson`), CSON.stringify(raw, null, 2))
+  return { ok: true, note: toNote(raw, key, storageKey) }
+}
+
+/**
+ * Permanently delete a note's `.cson` file (used by "完全に削除" from Trash).
+ * @param {string[]} roots
+ * @param {string} key
+ * @returns {{ ok: boolean, error?: string }}
+ */
+function deleteNote(roots, key) {
+  const k = String(key || '')
+  if (!k || /[/\\]/.test(k) || k.includes('..')) {
+    return { ok: false, error: 'invalid note key' }
+  }
+  for (const root of roots) {
+    if (!root) continue
+    const notesDir = path.join(root, 'notes')
+    const file = path.join(notesDir, `${k}.cson`)
+    if (path.dirname(file) !== notesDir) continue
+    if (fs.existsSync(file)) {
+      fs.unlinkSync(file)
+      return { ok: true }
+    }
+  }
+  return { ok: false, error: `note "${k}" not found in any storage` }
+}
+
+/**
  * Load several storage roots and aggregate them.
  * @param {string[]} roots
  * @returns {{ storages: object[], notes: object[] }}
@@ -115,4 +184,11 @@ function loadStorages(roots) {
   return { storages, notes }
 }
 
-module.exports = { loadStorage, loadStorages, toNote, saveNote }
+module.exports = {
+  loadStorage,
+  loadStorages,
+  toNote,
+  saveNote,
+  createNote,
+  deleteNote
+}

--- a/app/electron/main.cjs
+++ b/app/electron/main.cjs
@@ -12,7 +12,12 @@
 const { app, BrowserWindow, ipcMain, dialog } = require('electron')
 const fs = require('node:fs')
 const path = require('node:path')
-const { loadStorages, saveNote } = require('./loadNotes.cjs')
+const {
+  loadStorages,
+  saveNote,
+  createNote,
+  deleteNote
+} = require('./loadNotes.cjs')
 
 const configPath = () => path.join(app.getPath('userData'), 'config.json')
 
@@ -56,6 +61,26 @@ ipcMain.handle('notes:save', (_event, note) => {
     return saveNote(allRoots(), note)
   } catch (err) {
     console.error('notes:save failed:', err)
+    return { ok: false, error: String(err) }
+  }
+})
+
+// Create a new empty note in a storage.
+ipcMain.handle('notes:create', (_event, opts) => {
+  try {
+    return createNote(allRoots(), opts)
+  } catch (err) {
+    console.error('notes:create failed:', err)
+    return { ok: false, error: String(err) }
+  }
+})
+
+// Permanently delete a note's `.cson` file.
+ipcMain.handle('notes:delete', (_event, key) => {
+  try {
+    return deleteNote(allRoots(), key)
+  } catch (err) {
+    console.error('notes:delete failed:', err)
     return { ok: false, error: String(err) }
   }
 })

--- a/app/electron/preload.cjs
+++ b/app/electron/preload.cjs
@@ -8,5 +8,7 @@ const { contextBridge, ipcRenderer } = require('electron')
 contextBridge.exposeInMainWorld('boostnote', {
   loadNotes: () => ipcRenderer.invoke('notes:load'),
   pickStorage: () => ipcRenderer.invoke('notes:pickStorage'),
-  saveNote: note => ipcRenderer.invoke('notes:save', note)
+  saveNote: note => ipcRenderer.invoke('notes:save', note),
+  createNote: opts => ipcRenderer.invoke('notes:create', opts),
+  deleteNote: key => ipcRenderer.invoke('notes:delete', key)
 })

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -29,7 +29,9 @@ export default function App() {
   const [saveError, setSaveError] = useState<string | null>(null)
 
   const canPick = typeof repository.pickStorage === 'function'
+  const canCreate = typeof repository.createNote === 'function'
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const newNoteRef = useRef<() => void>(() => {})
 
   // Persist a note; failures surface in the header rather than being swallowed.
   function persist(note: Note) {
@@ -73,6 +75,18 @@ export default function App() {
     return () => {
       alive = false
     }
+  }, [])
+
+  // Cmd/Ctrl+N creates a new note (ref keeps the handler fresh without re-binding).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'n') {
+        e.preventDefault()
+        newNoteRef.current()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
   }, [])
 
   const visible = useMemo(() => {
@@ -130,6 +144,59 @@ export default function App() {
     persist(updated) // immediate write-back (single action)
   }
 
+  // Create a new note in the selected folder (or the first folder otherwise).
+  async function handleNewNote() {
+    if (!repository.createNote) return
+    let storage = storages[0]?.key
+    let folder = storages[0]?.folders[0]?.key
+    if (selection.kind === 'folder') {
+      const [s, f] = selection.value.split('|')
+      storage = s
+      folder = f
+    }
+    try {
+      setSaveError(null)
+      const note = await repository.createNote({ storage, folder })
+      setNotes(prev => [note, ...prev])
+      // Show the new (empty, untagged) note where it will actually appear.
+      setSelection(
+        storage && folder
+          ? { kind: 'folder', value: `${storage}|${folder}` }
+          : { kind: 'smart', value: 'all' }
+      )
+      setActiveKey(note.key)
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : String(e))
+    }
+  }
+  newNoteRef.current = handleNewNote
+
+  function setTrashed(isTrashed: boolean) {
+    if (!active) return
+    const updated: Note = {
+      ...active,
+      isTrashed,
+      updatedAt: new Date().toISOString()
+    }
+    setNotes(prev => prev.map(n => (n.key === updated.key ? updated : n)))
+    persist(updated)
+    setActiveKey(null) // the note leaves the current view
+  }
+
+  async function deleteActiveForever() {
+    if (!active || !repository.deleteNote) return
+    if (!window.confirm('このノートを完全に削除しますか？元に戻せません。')) return
+    const key = active.key
+    try {
+      setSaveError(null)
+      await repository.deleteNote(key)
+      setNotes(prev => prev.filter(n => n.key !== key))
+      setActiveKey(null)
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : String(e))
+    }
+  }
+
   const folderName = active
     ? (storages
         .find(s => s.key === active.storage)
@@ -151,6 +218,7 @@ export default function App() {
         onSelect={setActiveKey}
         query={query}
         onQueryChange={setQuery}
+        onNewNote={canCreate ? handleNewNote : undefined}
       />
       {active ? (
         <section className="detail">
@@ -162,14 +230,46 @@ export default function App() {
               </span>
             )}
             <span className="spacer" />
-            <span
-              className={`star ${active.isStarred ? 'on' : ''}`}
-              style={{ cursor: 'pointer' }}
-              onClick={toggleStar}
-              title="Star"
-            >
-              ★
-            </span>
+            {active.isTrashed ? (
+              <>
+                <button
+                  className="head-btn"
+                  onClick={() => setTrashed(false)}
+                  title="復元"
+                >
+                  ♻ 復元
+                </button>
+                {repository.deleteNote && (
+                  <button
+                    className="head-btn danger"
+                    onClick={deleteActiveForever}
+                    title="完全に削除"
+                  >
+                    ✕ 完全削除
+                  </button>
+                )}
+              </>
+            ) : (
+              <>
+                <span
+                  className={`star ${active.isStarred ? 'on' : ''}`}
+                  style={{ cursor: 'pointer' }}
+                  onClick={toggleStar}
+                  title="Star"
+                >
+                  ★
+                </span>
+                {repository.saveNote && (
+                  <button
+                    className="head-btn"
+                    onClick={() => setTrashed(true)}
+                    title="ゴミ箱へ移動"
+                  >
+                    🗑
+                  </button>
+                )}
+              </>
+            )}
           </div>
           <div className="split">
             <div className="pane editor">
@@ -203,7 +303,14 @@ export default function App() {
               )}
             </div>
           ) : (
-            'Select a note'
+            <div style={{ textAlign: 'center' }}>
+              <div style={{ marginBottom: 12 }}>ノートを選択してください</div>
+              {canCreate && (
+                <button className="btn-primary" onClick={handleNewNote}>
+                  ＋ 新規ノート
+                </button>
+              )}
+            </div>
           )}
         </div>
       )}

--- a/app/src/components/NoteList.tsx
+++ b/app/src/components/NoteList.tsx
@@ -7,6 +7,8 @@ interface Props {
   onSelect: (key: string) => void
   query: string
   onQueryChange: (q: string) => void
+  /** When set (Electron), shows a button to create a new note. */
+  onNewNote?: () => void
 }
 
 const ROW_H = 58 // fixed row height enables simple, fast windowing
@@ -26,7 +28,8 @@ export function NoteList({
   activeKey,
   onSelect,
   query,
-  onQueryChange
+  onQueryChange,
+  onNewNote
 }: Props) {
   const sorted = useMemo(
     () =>
@@ -84,6 +87,15 @@ export function NoteList({
         <span className="sort" style={{ marginLeft: 'auto' }}>
           {total} notes
         </span>
+        {onNewNote && (
+          <button
+            className="head-btn"
+            onClick={onNewNote}
+            title="新規ノート (⌘/Ctrl+N)"
+          >
+            ＋
+          </button>
+        )}
       </div>
       <div
         className="notelist-scroll"

--- a/app/src/data/repository.ts
+++ b/app/src/data/repository.ts
@@ -13,6 +13,10 @@ export interface NotesRepository {
   pickStorage?(): Promise<{ storages: Storage[]; notes: Note[] } | null>
   /** Persist an edited note. Present only when notes are backed by real files. */
   saveNote?(note: Note): Promise<void>
+  /** Create a new empty note in a storage/folder and return it. */
+  createNote?(opts: { storage?: string; folder?: string }): Promise<Note>
+  /** Permanently delete a note by key. */
+  deleteNote?(key: string): Promise<void>
 }
 
 // Deterministic (no Math.random) generator so the list reaches realistic
@@ -81,6 +85,17 @@ export function createElectronRepository(): NotesRepository {
     async saveNote(note) {
       const res = await window.boostnote!.saveNote(note)
       if (!res.ok) throw new Error(res.error || 'note の保存に失敗しました')
+    },
+    async createNote(opts) {
+      const res = await window.boostnote!.createNote(opts)
+      if (!res.ok || !res.note) {
+        throw new Error(res.error || 'ノートの作成に失敗しました')
+      }
+      return res.note
+    },
+    async deleteNote(key) {
+      const res = await window.boostnote!.deleteNote(key)
+      if (!res.ok) throw new Error(res.error || 'ノートの削除に失敗しました')
     }
   }
 }

--- a/app/src/electron.d.ts
+++ b/app/src/electron.d.ts
@@ -12,6 +12,18 @@ export interface SaveResult {
   error?: string
 }
 
+export interface CreateResult {
+  ok: boolean
+  note?: Note
+  error?: string
+}
+
+export interface CreateNoteOptions {
+  storage?: string
+  folder?: string
+  content?: string
+}
+
 // The preload bridge (electron/preload.cjs). Present only when running inside
 // Electron; the browser foundation falls back to the in-memory repository.
 declare global {
@@ -20,6 +32,8 @@ declare global {
       loadNotes(): Promise<LoadResult>
       pickStorage(): Promise<LoadResult | null>
       saveNote(note: Note): Promise<SaveResult>
+      createNote(opts: CreateNoteOptions): Promise<CreateResult>
+      deleteNote(key: string): Promise<SaveResult>
     }
   }
 }

--- a/app/src/theme.css
+++ b/app/src/theme.css
@@ -99,6 +99,15 @@ body {
 .detail-head .spacer { margin-left: auto; }
 .detail-head .star.on { color: var(--accent); }
 .detail-head .save-error { color: var(--accent); font-size: 12px; cursor: default; }
+
+.head-btn {
+  font: inherit; font-size: 13px; cursor: pointer;
+  background: transparent; color: var(--muted);
+  border: 1px solid var(--border); border-radius: var(--radius);
+  padding: 2px 9px; margin-left: 6px; line-height: 1.6;
+}
+.head-btn:hover { background: #2a2e36; color: var(--fg); }
+.head-btn.danger:hover { background: var(--accent); color: #fff; border-color: transparent; }
 .split { flex: 1; display: flex; min-height: 0; }
 .pane { flex: 1; min-width: 0; overflow: auto; }
 .pane.editor { border-right: 1px solid var(--border); }

--- a/app/test/crud.test.mjs
+++ b/app/test/crud.test.mjs
@@ -1,0 +1,70 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const { createNote, deleteNote, loadStorage } = require('../electron/loadNotes.cjs')
+
+function makeStorage(name) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bn-crud-'))
+  fs.writeFileSync(
+    path.join(root, 'boostnote.json'),
+    JSON.stringify({ name: name || 'S', folders: [{ key: 'f1', name: 'Inbox' }] })
+  )
+  fs.mkdirSync(path.join(root, 'notes'))
+  return root
+}
+
+test('createNote writes a loadable empty note in the storage', () => {
+  const root = makeStorage()
+  const res = createNote([root], { storage: path.basename(root), folder: 'f1' })
+  assert.equal(res.ok, true)
+  assert.ok(res.note.key)
+  assert.equal(res.note.isTrashed, false)
+  assert.equal(res.note.folder, 'f1')
+  assert.equal(res.note.type, 'MARKDOWN_NOTE')
+
+  // it is a real file the loader can read back
+  const { notes } = loadStorage(root)
+  assert.equal(notes.length, 1)
+  assert.equal(notes[0].key, res.note.key)
+
+  fs.rmSync(root, { recursive: true, force: true })
+})
+
+test('createNote falls back to the first root when storage is unknown', () => {
+  const root = makeStorage()
+  const res = createNote([root], { storage: 'does-not-exist' })
+  assert.equal(res.ok, true)
+  assert.equal(fs.readdirSync(path.join(root, 'notes')).length, 1)
+  fs.rmSync(root, { recursive: true, force: true })
+})
+
+test('createNote returns ok:false when there is no storage', () => {
+  const res = createNote([], {})
+  assert.equal(res.ok, false)
+})
+
+test('deleteNote removes the file; deleting again reports not found', () => {
+  const root = makeStorage()
+  const { note } = createNote([root], { storage: path.basename(root) })
+  const first = deleteNote([root], note.key)
+  assert.equal(first.ok, true)
+  assert.equal(fs.existsSync(path.join(root, 'notes', `${note.key}.cson`)), false)
+
+  const second = deleteNote([root], note.key)
+  assert.equal(second.ok, false)
+  assert.match(second.error, /not found/)
+  fs.rmSync(root, { recursive: true, force: true })
+})
+
+test('deleteNote rejects keys with path separators or traversal', () => {
+  const root = makeStorage()
+  for (const bad of ['../x', 'a/b', '..\\y', '']) {
+    assert.equal(deleteNote([root], bad).ok, false)
+  }
+  fs.rmSync(root, { recursive: true, force: true })
+})

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@
 | パス | 内容 | ランタイム |
 |---|---|---|
 | `browser/`, `lib/` | **レガシー本体**（Electron 4 + React 16 + Redux + webpack 1、`.cson` ファイル保存）。保守モードで安定化中 | Node 14 |
-| `app/` | **モダンアプリ土台**（Vite + React 19 + TypeScript + CodeMirror 6）。3ペインUXを再現し、実 `.cson` の読込・編集の書き戻し保存（オートセーブ）・全文検索・仮想化リスト・フォルダピッカーに対応。Electron 42 で配布 | Node 22 |
+| `app/` | **モダンアプリ土台**（Vite + React 19 + TypeScript + CodeMirror 6）。3ペインUXを再現し、実 `.cson` の読込・新規作成・編集の書き戻し保存（オートセーブ）・ゴミ箱（移動/復元/完全削除）・全文検索・仮想化リスト・フォルダピッカーに対応。Electron 42 で配布 | Node 22 |
 | `poc/collab-core/` | **共同編集コアの実証**（Yjs + CodeMirror 6 + self-host Hocuspocus + `.cson` スナップショット、device-pairing 認証） | Node 22 |
 | `docs/` | モダナイゼーション設計判断書（スタック選定・脅威モデル・移行ロードマップ、事実検証済み） | — |
 | `.claude/skills/boostnote-modernize` | アーキテクチャ判断・作業方針をまとめた Claude Code スキル | — |


### PR DESCRIPTION
## 概要
読込・更新（オートセーブ）に続き、**作成**と**削除**を実装。モダンアプリのノート CRUD が一通り揃った。

## 変更点
- **loadNotes.cjs**: `createNote`（`storage` を basename で照合、無ければ先頭 root にフォールバック。`crypto.randomUUID` で key 生成、空の MARKDOWN ノートを書き出し `toNote` 形で返す） / `deleteNote`（key をサニタイズしトラバーサル拒否、`.cson` を `unlink`）を追加。
- **main.cjs**: `notes:create` / `notes:delete` IPC。
- **preload.cjs / electron.d.ts**: `createNote` / `deleteNote` を公開・型付け（`CreateResult` 等）。
- **repository.ts**: `NotesRepository` に `createNote` / `deleteNote`（任意）。
- **App.tsx**:
  - **＋新規ノート（⌘/Ctrl+N）**。選択中フォルダ、無ければ先頭フォルダに作成し、可視ビューに切替えて選択。
  - **ゴミ箱へ移動 / 復元**（`isTrashed` トグル＋即時保存）。
  - **完全削除**（`confirm` 後にファイル削除）。
  - 空状態に「＋新規ノート」導線。失敗はヘッダ表示で握りつぶさない。
- **NoteList.tsx**: ヘッダに ＋ ボタン（`onNewNote`）。
- **theme.css**: `.head-btn` / `.danger` スタイル。
- **test/crud.test.mjs（新規）**: create/delete の round-trip・フォールバック・未検出・トラバーサル拒否を網羅（5 ケース）。
- **readme.md**: 対応機能に新規作成・ゴミ箱を追記。

## 安全性
- `deleteNote` / `createNote` とも key／path をサニタイズしトラバーサルを遮断。
- ブラウザ土台（in-memory）は `createNote`/`saveNote` 未提供のため該当ボタンは**非表示＝安全に degrade**。

## 検証
`npm run lint` / `npm run build` / `npm test`（**18 pass**: loadNotes 2 + search 7 + saveNote 4 + crud 5）すべて緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)