### PR TITLE
app: タグ編集（付与/削除）を追加

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -6,6 +6,7 @@ import { Sidebar } from './components/Sidebar'
 import { NoteList } from './components/NoteList'
 import { MarkdownEditor } from './components/MarkdownEditor'
 import { Preview } from './components/Preview'
+import { TagEditor } from './components/TagEditor'
 
 function firstTitle(content: string, fallback: string) {
   const line = content.split('\n').find(l => l.trim().length > 0)
@@ -144,6 +145,17 @@ export default function App() {
     persist(updated) // immediate write-back (single action)
   }
 
+  function updateTags(tags: string[]) {
+    if (!active) return
+    const updated: Note = {
+      ...active,
+      tags,
+      updatedAt: new Date().toISOString()
+    }
+    setNotes(prev => prev.map(n => (n.key === updated.key ? updated : n)))
+    persist(updated)
+  }
+
   // Create a new note in the selected folder (or the first folder otherwise).
   async function handleNewNote() {
     if (!repository.createNote) return
@@ -271,6 +283,13 @@ export default function App() {
               </>
             )}
           </div>
+          {!active.isTrashed && (
+            <TagEditor
+              key={active.key}
+              tags={active.tags}
+              onChange={updateTags}
+            />
+          )}
           <div className="split">
             <div className="pane editor">
               <MarkdownEditor

--- a/app/src/components/TagEditor.tsx
+++ b/app/src/components/TagEditor.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react'
+import { addTag, removeTag } from '../data/tags'
+
+interface Props {
+  tags: string[]
+  onChange: (tags: string[]) => void
+}
+
+/** Inline tag editor: chips with remove, plus an input that adds on Enter/comma. */
+export function TagEditor({ tags, onChange }: Props) {
+  const [draft, setDraft] = useState('')
+
+  function commit() {
+    const next = addTag(tags, draft)
+    if (next !== tags) onChange(next)
+    setDraft('')
+  }
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault()
+      commit()
+    } else if (e.key === 'Backspace' && draft === '' && tags.length > 0) {
+      onChange(removeTag(tags, tags[tags.length - 1]))
+    }
+  }
+
+  return (
+    <div className="tag-bar">
+      {tags.map(tag => (
+        <span key={tag} className="tag-chip">
+          #{tag}
+          <button
+            className="tag-x"
+            onClick={() => onChange(removeTag(tags, tag))}
+            title="タグを削除"
+          >
+            ×
+          </button>
+        </span>
+      ))}
+      <input
+        className="tag-input"
+        value={draft}
+        placeholder="＋ タグ"
+        onChange={e => setDraft(e.target.value)}
+        onKeyDown={onKeyDown}
+        onBlur={commit}
+      />
+    </div>
+  )
+}

--- a/app/src/data/tags.ts
+++ b/app/src/data/tags.ts
@@ -1,0 +1,21 @@
+/**
+ * Tag helpers — pure functions so the rules (normalize, dedupe) are testable
+ * and shared between the editor UI and any future callers.
+ */
+
+/** Normalize a raw tag: trim and collapse inner whitespace to hyphens. */
+export function normalizeTag(raw: string): string {
+  return raw.trim().replace(/\s+/g, '-')
+}
+
+/** Add a normalized tag if non-empty and not already present (order kept). */
+export function addTag(tags: string[], raw: string): string[] {
+  const tag = normalizeTag(raw)
+  if (!tag || tags.includes(tag)) return tags
+  return [...tags, tag]
+}
+
+/** Remove a tag (returns the same array reference when nothing changes). */
+export function removeTag(tags: string[], tag: string): string[] {
+  return tags.includes(tag) ? tags.filter(t => t !== tag) : tags
+}

--- a/app/src/electron.d.ts
+++ b/app/src/electron.d.ts
@@ -37,5 +37,3 @@ declare global {
     }
   }
 }
-
-export {}

--- a/app/src/theme.css
+++ b/app/src/theme.css
@@ -59,6 +59,22 @@ body {
 .tag-chip:hover { color: var(--fg); }
 .tag-chip.active { background: var(--accent); color: #fff; }
 
+/* ---- Tag editor (detail) --------------------------------------------- */
+.tag-bar {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 2px;
+  padding: 6px 12px; border-bottom: 1px solid var(--border);
+}
+.tag-bar .tag-x {
+  font: inherit; cursor: pointer; border: none; background: none;
+  color: var(--faint); padding: 0 0 0 4px; line-height: 1;
+}
+.tag-bar .tag-x:hover { color: var(--accent); }
+.tag-input {
+  font: inherit; color: var(--fg); background: transparent;
+  border: none; outline: none; padding: 2px 6px; min-width: 80px;
+}
+.tag-input::placeholder { color: var(--faint); }
+
 /* ---- Note list -------------------------------------------------------- */
 .notelist { background: var(--bg-list); border-right: 1px solid var(--border); display: flex; flex-direction: column; min-width: 0; }
 .notelist-search { padding: 8px 10px; border-bottom: 1px solid var(--border); }

--- a/app/test/tags.test.mjs
+++ b/app/test/tags.test.mjs
@@ -1,0 +1,29 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { normalizeTag, addTag, removeTag } from '../src/data/tags.ts'
+
+test('normalizeTag trims and hyphenates inner whitespace', () => {
+  assert.equal(normalizeTag('  hello  '), 'hello')
+  assert.equal(normalizeTag('to do'), 'to-do')
+  assert.equal(normalizeTag('a   b\tc'), 'a-b-c')
+  assert.equal(normalizeTag('   '), '')
+})
+
+test('addTag appends non-empty, deduped, order preserved', () => {
+  assert.deepEqual(addTag(['a'], 'b'), ['a', 'b'])
+  assert.deepEqual(addTag(['a'], '  a '), ['a']) // dup after normalize
+  assert.deepEqual(addTag(['a'], '   '), ['a']) // empty ignored
+  assert.deepEqual(addTag([], 'in progress'), ['in-progress'])
+})
+
+test('addTag returns the same array when nothing is added', () => {
+  const tags = ['a']
+  assert.equal(addTag(tags, 'a'), tags)
+  assert.equal(addTag(tags, ''), tags)
+})
+
+test('removeTag removes a tag, no-op when absent', () => {
+  assert.deepEqual(removeTag(['a', 'b'], 'a'), ['b'])
+  const tags = ['a', 'b']
+  assert.equal(removeTag(tags, 'z'), tags) // unchanged reference
+})

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@
 | パス | 内容 | ランタイム |
 |---|---|---|
 | `browser/`, `lib/` | **レガシー本体**（Electron 4 + React 16 + Redux + webpack 1、`.cson` ファイル保存）。保守モードで安定化中 | Node 14 |
-| `app/` | **モダンアプリ土台**（Vite + React 19 + TypeScript + CodeMirror 6）。3ペインUXを再現し、実 `.cson` の読込・新規作成・編集の書き戻し保存（オートセーブ）・ゴミ箱（移動/復元/完全削除）・全文検索・仮想化リスト・フォルダピッカーに対応。Electron 42 で配布 | Node 22 |
+| `app/` | **モダンアプリ土台**（Vite + React 19 + TypeScript + CodeMirror 6）。3ペインUXを再現し、実 `.cson` の読込・新規作成・編集の書き戻し保存（オートセーブ）・タグ編集・ゴミ箱（移動/復元/完全削除）・全文検索・仮想化リスト・フォルダピッカーに対応。Electron 42 で配布 | Node 22 |
 | `poc/collab-core/` | **共同編集コアの実証**（Yjs + CodeMirror 6 + self-host Hocuspocus + `.cson` スナップショット、device-pairing 認証） | Node 22 |
 | `docs/` | モダナイゼーション設計判断書（スタック選定・脅威モデル・移行ロードマップ、事実検証済み） | — |
 | `.claude/skills/boostnote-modernize` | アーキテクチャ判断・作業方針をまとめた Claude Code スキル | — |


### PR DESCRIPTION
## 概要
サイドバーはタグでフィルタできるのに**タグを付与する手段が無かった**（機能が片側だけ）。詳細ヘッダ直下にタグ編集バーを追加し、機能の両端を揃える。

## 変更点
- **data/tags.ts（新規）**: `normalizeTag` / `addTag` / `removeTag` の純関数（trim・内部空白のハイフン化・重複排除・順序保持）。
- **components/TagEditor.tsx（新規）**: チップ＋入力の単一責務コンポーネント。**Enter / カンマ / blur** で確定、空入力での **Backspace** で末尾タグ削除。
- **App.tsx**: `updateTags`（tags 更新＋即時保存）。詳細に `TagEditor` を `active.key` で key 付けして描画（ノート切替で draft をリセット）。ゴミ箱中は非表示。
- **theme.css**: `.tag-bar` / `.tag-input` / `.tag-x` スタイル。
- **electron.d.ts**: 実 export を持つため不要になった `export {}` を削除（`no-useless-empty-export` 警告を解消）。
- **test/tags.test.mjs（新規）**: 純関数の単体テスト（4 ケース）。
- **readme.md**: 対応機能にタグ編集を追記。

## 設計メモ
- `tags` は `saveNote` の編集可能フィールドなので**永続化済み**。
- ブラウザ土台（in-memory）は state 更新のみ（保存は no-op）で安全に degrade。

## 検証
`npm run lint`（**警告ゼロ**）/ `npm run build` / `npm test`（**22 pass**: loadNotes 2 + search 7 + saveNote 4 + crud 5 + tags 4）すべて緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)