### PR TITLE
app: ノートのフォルダ移動を追加

### DIFF
--- a/app/electron/loadNotes.cjs
+++ b/app/electron/loadNotes.cjs
@@ -63,7 +63,15 @@ function loadStorage(rootDir, storageKey) {
 
 // Fields the renderer may change; everything else in the raw `.cson` (e.g. a
 // SNIPPET_NOTE's `snippets` array, or any unknown keys) is preserved untouched.
-const EDITABLE = ['title', 'content', 'tags', 'isStarred', 'isTrashed', 'updatedAt']
+const EDITABLE = [
+  'title',
+  'content',
+  'tags',
+  'folder',
+  'isStarred',
+  'isTrashed',
+  'updatedAt'
+]
 
 /**
  * Write an edited note back to its `.cson` file, preserving every field the

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -156,6 +156,17 @@ export default function App() {
     persist(updated)
   }
 
+  function moveToFolder(folder: string) {
+    if (!active || folder === active.folder) return
+    const updated: Note = {
+      ...active,
+      folder,
+      updatedAt: new Date().toISOString()
+    }
+    setNotes(prev => prev.map(n => (n.key === updated.key ? updated : n)))
+    persist(updated)
+  }
+
   // Create a new note in the selected folder (or the first folder otherwise).
   async function handleNewNote() {
     if (!repository.createNote) return
@@ -209,11 +220,14 @@ export default function App() {
     }
   }
 
-  const folderName = active
-    ? (storages
-        .find(s => s.key === active.storage)
-        ?.folders.find(f => f.key === active.folder)?.name ?? active.folder)
-    : ''
+  const activeFolders = active
+    ? (storages.find(s => s.key === active.storage)?.folders ?? [])
+    : []
+  const folderName =
+    activeFolders.find(f => f.key === active?.folder)?.name ??
+    active?.folder ??
+    ''
+  const canMove = typeof repository.saveNote === 'function' && activeFolders.length > 0
 
   return (
     <div className="app">
@@ -235,7 +249,25 @@ export default function App() {
       {active ? (
         <section className="detail">
           <div className="detail-head">
-            <span className="folder">📁 {folderName}</span>
+            {canMove && !active.isTrashed ? (
+              <label className="folder">
+                📁{' '}
+                <select
+                  className="folder-select"
+                  value={active.folder}
+                  onChange={e => moveToFolder(e.target.value)}
+                  title="フォルダを移動"
+                >
+                  {activeFolders.map(f => (
+                    <option key={f.key} value={f.key}>
+                      {f.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            ) : (
+              <span className="folder">📁 {folderName}</span>
+            )}
             {saveError && (
               <span className="save-error" title={saveError}>
                 ⚠ 保存に失敗しました

--- a/app/src/theme.css
+++ b/app/src/theme.css
@@ -112,6 +112,12 @@ body {
   padding: 9px 14px; border-bottom: 1px solid var(--border); color: var(--muted);
 }
 .detail-head .folder { color: var(--fg); font-weight: 600; }
+.folder-select {
+  font: inherit; font-weight: 600; color: var(--fg);
+  background: var(--bg-elev); border: 1px solid var(--border);
+  border-radius: var(--radius); padding: 2px 6px; cursor: pointer;
+}
+.folder-select:focus { outline: none; border-color: var(--accent); }
 .detail-head .spacer { margin-left: auto; }
 .detail-head .star.on { color: var(--accent); }
 .detail-head .save-error { color: var(--accent); font-size: 12px; cursor: default; }

--- a/app/test/saveNote.test.mjs
+++ b/app/test/saveNote.test.mjs
@@ -64,6 +64,20 @@ test('saveNote updates editable fields and preserves the rest', () => {
   fs.rmSync(root, { recursive: true, force: true })
 })
 
+test('saveNote can move a note to another folder', () => {
+  const root = makeStorage({
+    type: 'MARKDOWN_NOTE',
+    folder: 'f1',
+    content: 'x',
+    createdAt: '2025-01-01T00:00:00.000Z'
+  })
+  const res = saveNote([root], { key: 'n1', folder: 'f2' })
+  assert.equal(res.ok, true)
+  const { notes } = loadStorage(root)
+  assert.equal(notes[0].folder, 'f2')
+  fs.rmSync(root, { recursive: true, force: true })
+})
+
 test('saveNote leaves no temp file behind (atomic)', () => {
   const root = makeStorage({ type: 'MARKDOWN_NOTE', content: 'x', createdAt: '2025-01-01' })
   saveNote([root], { key: 'n1', content: 'y' })

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@
 | パス | 内容 | ランタイム |
 |---|---|---|
 | `browser/`, `lib/` | **レガシー本体**（Electron 4 + React 16 + Redux + webpack 1、`.cson` ファイル保存）。保守モードで安定化中 | Node 14 |
-| `app/` | **モダンアプリ土台**（Vite + React 19 + TypeScript + CodeMirror 6）。3ペインUXを再現し、実 `.cson` の読込・新規作成・編集の書き戻し保存（オートセーブ）・タグ編集・ゴミ箱（移動/復元/完全削除）・全文検索・仮想化リスト・フォルダピッカーに対応。Electron 42 で配布 | Node 22 |
+| `app/` | **モダンアプリ土台**（Vite + React 19 + TypeScript + CodeMirror 6）。3ペインUXを再現し、実 `.cson` の読込・新規作成・編集の書き戻し保存（オートセーブ）・タグ編集・フォルダ移動・ゴミ箱（移動/復元/完全削除）・全文検索・仮想化リスト・フォルダピッカーに対応。Electron 42 で配布 | Node 22 |
 | `poc/collab-core/` | **共同編集コアの実証**（Yjs + CodeMirror 6 + self-host Hocuspocus + `.cson` スナップショット、device-pairing 認証） | Node 22 |
 | `docs/` | モダナイゼーション設計判断書（スタック選定・脅威モデル・移行ロードマップ、事実検証済み） | — |
 | `.claude/skills/boostnote-modernize` | アーキテクチャ判断・作業方針をまとめた Claude Code スキル | — |


### PR DESCRIPTION
## 概要
組織化機能の仕上げ。詳細ヘッダのフォルダ名を**ドロップダウン化**し、ストレージ内の別フォルダへノートを移動できるようにする。

## 変更点
- **loadNotes.cjs**: `saveNote` の `EDITABLE` に `folder` を追加（書き戻し対象に）。`undefined` ガードのため未指定時は従来どおり温存。
- **App.tsx**: `moveToFolder`（同一フォルダなら no-op、変更時のみ更新＋即時保存）。`detail-head` に `activeFolders` を列挙する `select` を描画（`canMove` = `saveNote` 有 かつ フォルダ有、ゴミ箱中は静的表示）。
- **theme.css**: `.folder-select` スタイル。
- **test/saveNote.test.mjs**: フォルダ移動が round-trip で永続化されることを検証（1 ケース追加）。
- **readme.md**: 対応機能にフォルダ移動を追記。

## 検証
`npm run lint`（**警告ゼロ**）/ `npm run build` / `npm test`（**23 pass**: loadNotes 2 + search 7 + saveNote 5 + crud 5 + tags 4）すべて緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)