### PR TITLE
app: ノート一覧のソート切替（更新/作成/タイトル × 昇降順）

### DIFF
--- a/app/src/components/NoteList.tsx
+++ b/app/src/components/NoteList.tsx
@@ -1,5 +1,21 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { Note } from '../types'
+import { sortNotes, SORT_LABELS } from '../data/sort'
+import type { SortKey, SortDir } from '../data/sort'
+
+const SORT_STORE = 'theboosters_sort'
+
+function loadSort(): { key: SortKey; dir: SortDir } {
+  try {
+    const raw = JSON.parse(localStorage.getItem(SORT_STORE) || '')
+    if (raw && raw.key in SORT_LABELS && (raw.dir === 'asc' || raw.dir === 'desc')) {
+      return raw
+    }
+  } catch {
+    /* fall through to default */
+  }
+  return { key: 'updated', dir: 'desc' }
+}
 
 interface Props {
   notes: Note[]
@@ -31,11 +47,20 @@ export function NoteList({
   onQueryChange,
   onNewNote
 }: Props) {
+  const [sort, setSort] = useState(loadSort)
   const sorted = useMemo(
-    () =>
-      [...notes].sort((a, b) => +new Date(b.updatedAt) - +new Date(a.updatedAt)),
-    [notes]
+    () => sortNotes(notes, sort.key, sort.dir),
+    [notes, sort]
   )
+
+  // Persist the sort choice so it survives reloads.
+  useEffect(() => {
+    try {
+      localStorage.setItem(SORT_STORE, JSON.stringify(sort))
+    } catch {
+      /* localStorage unavailable — non-fatal */
+    }
+  }, [sort])
 
   const scrollRef = useRef<HTMLDivElement>(null)
   const searchRef = useRef<HTMLInputElement>(null)
@@ -83,7 +108,27 @@ export function NoteList({
         />
       </div>
       <div className="notelist-head">
-        <span>⌄ Updated</span>
+        <select
+          className="sort-select"
+          value={sort.key}
+          onChange={e => setSort(s => ({ ...s, key: e.target.value as SortKey }))}
+          title="並び替え"
+        >
+          {(Object.keys(SORT_LABELS) as SortKey[]).map(k => (
+            <option key={k} value={k}>
+              {SORT_LABELS[k]}
+            </option>
+          ))}
+        </select>
+        <button
+          className="sort-dir"
+          onClick={() =>
+            setSort(s => ({ ...s, dir: s.dir === 'asc' ? 'desc' : 'asc' }))
+          }
+          title={sort.dir === 'asc' ? '昇順' : '降順'}
+        >
+          {sort.dir === 'asc' ? '▲' : '▼'}
+        </button>
         <span className="sort" style={{ marginLeft: 'auto' }}>
           {total} notes
         </span>

--- a/app/src/data/sort.ts
+++ b/app/src/data/sort.ts
@@ -1,0 +1,24 @@
+import type { Note } from '../types'
+
+/** Sort options for the note list. */
+export type SortKey = 'updated' | 'created' | 'title'
+export type SortDir = 'asc' | 'desc'
+
+export const SORT_LABELS: Record<SortKey, string> = {
+  updated: '更新日',
+  created: '作成日',
+  title: 'タイトル'
+}
+
+/** Pure, stable-ish note sort by a key and direction (returns a new array). */
+export function sortNotes(notes: Note[], key: SortKey, dir: SortDir): Note[] {
+  const sign = dir === 'asc' ? 1 : -1
+  return [...notes].sort((a, b) => {
+    if (key === 'title') {
+      return a.title.localeCompare(b.title) * sign
+    }
+    const fa = key === 'created' ? a.createdAt : a.updatedAt
+    const fb = key === 'created' ? b.createdAt : b.updatedAt
+    return (+new Date(fa) - +new Date(fb)) * sign
+  })
+}

--- a/app/src/theme.css
+++ b/app/src/theme.css
@@ -90,6 +90,18 @@ body {
   padding: 10px 14px; border-bottom: 1px solid var(--border); color: var(--muted);
 }
 .notelist-head .sort { font-size: 12px; }
+.sort-select {
+  font: inherit; font-size: 12px; color: var(--fg);
+  background: var(--bg-elev); border: 1px solid var(--border);
+  border-radius: var(--radius); padding: 2px 4px; cursor: pointer;
+}
+.sort-select:focus { outline: none; border-color: var(--accent); }
+.sort-dir {
+  font: inherit; font-size: 11px; cursor: pointer; margin-left: 4px;
+  color: var(--muted); background: transparent;
+  border: 1px solid var(--border); border-radius: var(--radius); padding: 1px 6px;
+}
+.sort-dir:hover { color: var(--fg); background: #2a2e36; }
 .notelist-scroll { overflow-y: auto; flex: 1; }
 .note-row {
   padding: 10px 14px; border-bottom: 1px solid #20242b; cursor: pointer; min-width: 0;

--- a/app/test/sort.test.mjs
+++ b/app/test/sort.test.mjs
@@ -1,0 +1,59 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { sortNotes } from '../src/data/sort.ts'
+
+const note = (key, over) => ({
+  key,
+  type: 'MARKDOWN_NOTE',
+  title: '',
+  content: '',
+  tags: [],
+  storage: 's',
+  folder: 'f',
+  isStarred: false,
+  isTrashed: false,
+  createdAt: '2025-01-01T00:00:00.000Z',
+  updatedAt: '2025-01-01T00:00:00.000Z',
+  ...over
+})
+
+const notes = [
+  note('a', {
+    title: 'Banana',
+    createdAt: '2025-01-03T00:00:00.000Z',
+    updatedAt: '2025-01-01T00:00:00.000Z'
+  }),
+  note('b', {
+    title: 'Apple',
+    createdAt: '2025-01-01T00:00:00.000Z',
+    updatedAt: '2025-01-03T00:00:00.000Z'
+  }),
+  note('c', {
+    title: 'Cherry',
+    createdAt: '2025-01-02T00:00:00.000Z',
+    updatedAt: '2025-01-02T00:00:00.000Z'
+  })
+]
+
+const keys = arr => arr.map(n => n.key)
+
+test('updated desc/asc', () => {
+  assert.deepEqual(keys(sortNotes(notes, 'updated', 'desc')), ['b', 'c', 'a'])
+  assert.deepEqual(keys(sortNotes(notes, 'updated', 'asc')), ['a', 'c', 'b'])
+})
+
+test('created desc/asc', () => {
+  assert.deepEqual(keys(sortNotes(notes, 'created', 'desc')), ['a', 'c', 'b'])
+  assert.deepEqual(keys(sortNotes(notes, 'created', 'asc')), ['b', 'c', 'a'])
+})
+
+test('title asc/desc (locale compare)', () => {
+  assert.deepEqual(keys(sortNotes(notes, 'title', 'asc')), ['b', 'a', 'c'])
+  assert.deepEqual(keys(sortNotes(notes, 'title', 'desc')), ['c', 'a', 'b'])
+})
+
+test('does not mutate the input array', () => {
+  const before = keys(notes)
+  sortNotes(notes, 'title', 'asc')
+  assert.deepEqual(keys(notes), before)
+})

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@
 | パス | 内容 | ランタイム |
 |---|---|---|
 | `browser/`, `lib/` | **レガシー本体**（Electron 4 + React 16 + Redux + webpack 1、`.cson` ファイル保存）。保守モードで安定化中 | Node 14 |
-| `app/` | **モダンアプリ土台**（Vite + React 19 + TypeScript + CodeMirror 6）。3ペインUXを再現し、実 `.cson` の読込・新規作成・編集の書き戻し保存（オートセーブ）・タグ編集・フォルダ移動・ゴミ箱（移動/復元/完全削除）・全文検索・KaTeX 数式プレビュー・仮想化リスト・フォルダピッカーに対応。Electron 42 で配布 | Node 22 |
+| `app/` | **モダンアプリ土台**（Vite + React 19 + TypeScript + CodeMirror 6）。3ペインUXを再現し、実 `.cson` の読込・新規作成・編集の書き戻し保存（オートセーブ）・タグ編集・フォルダ移動・ゴミ箱（移動/復元/完全削除）・全文検索・一覧ソート（更新/作成/タイトル）・KaTeX 数式プレビュー・仮想化リスト・フォルダピッカーに対応。Electron 42 で配布 | Node 22 |
 | `poc/collab-core/` | **共同編集コアの実証**（Yjs + CodeMirror 6 + self-host Hocuspocus + `.cson` スナップショット、device-pairing 認証） | Node 22 |
 | `docs/` | モダナイゼーション設計判断書（スタック選定・脅威モデル・移行ロードマップ、事実検証済み） | — |
 | `.claude/skills/boostnote-modernize` | アーキテクチャ判断・作業方針をまとめた Claude Code スキル | — |


### PR DESCRIPTION
## 概要
ヘッダの「⌄ Updated」は固定表示だったが、実際に**並び替えられる**ようアフォーダンスを完成。

## 変更点
- **data/sort.ts（新規）**: `sortNotes`（更新日 / 作成日 / タイトル × asc/desc）の純関数 ＋ `SORT_LABELS`。タイトルは `localeCompare`、日付は数値比較。
- **NoteList.tsx**: ソート状態を **localStorage**（`theboosters_sort`）に永続化。ヘッダにキー `select` ＋ 昇降順トグル（▲/▼）。固定ソートを置換。
- **theme.css**: `.sort-select` / `.sort-dir` スタイル。
- **test/sort.test.mjs（新規）**: 各キー×方向、非破壊（入力を変更しない）を検証（4 ケース）。
- **readme.md**: 対応機能に一覧ソートを追記。

## 検証
`npm run lint`（**警告ゼロ**）/ `npm run build` / `npm test`（**31 pass**: loadNotes 2 + search 7 + saveNote 5 + crud 5 + tags 4 + math 4 + sort 4）すべて緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)