### PR TITLE
app: コードブロックのシンタックスハイライトを追加

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -27,6 +27,7 @@
         "electron": "^42.5.0",
         "electron-builder": "^25.1.8",
         "happy-dom": "^20.10.6",
+        "highlight.js": "^11.11.1",
         "katex": "^0.17.0",
         "markdown-it": "^14.2.0",
         "oxlint": "^1.69.0",
@@ -3674,6 +3675,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hosted-git-info": {

--- a/app/package.json
+++ b/app/package.json
@@ -43,6 +43,7 @@
     "electron": "^42.5.0",
     "electron-builder": "^25.1.8",
     "happy-dom": "^20.10.6",
+    "highlight.js": "^11.11.1",
     "katex": "^0.17.0",
     "markdown-it": "^14.2.0",
     "oxlint": "^1.69.0",

--- a/app/src/components/Preview.tsx
+++ b/app/src/components/Preview.tsx
@@ -2,7 +2,9 @@ import { useEffect, useMemo, useRef } from 'react'
 import MarkdownIt from 'markdown-it'
 import DOMPurify from 'dompurify'
 import katexPlugin from '@vscode/markdown-it-katex'
+import { highlightCode } from '../markdown/highlight'
 import 'katex/dist/katex.min.css'
+import 'highlight.js/styles/github-dark.css'
 
 /**
  * Markdown preview. Reuses the legacy app's pipeline (markdown-it) but renders
@@ -14,7 +16,12 @@ import 'katex/dist/katex.min.css'
 export function Preview({ content }: { content: string }) {
   const host = useRef<HTMLDivElement>(null)
   const md = useMemo(() => {
-    const m = new MarkdownIt({ html: false, linkify: true, breaks: true })
+    const m = new MarkdownIt({
+      html: false,
+      linkify: true,
+      breaks: true,
+      highlight: highlightCode
+    })
     m.use(katexPlugin, { throwOnError: false, output: 'html' })
     return m
   }, [])

--- a/app/src/markdown/highlight.ts
+++ b/app/src/markdown/highlight.ts
@@ -1,0 +1,53 @@
+// Code-block syntax highlighting for the preview. We import highlight.js core
+// plus a curated language subset (not the full bundle) so only these languages
+// are shipped — keeping the bundle lean. Built-in aliases (js, ts, html, sh, …)
+// are registered automatically with their parent language.
+import hljs from 'highlight.js/lib/core'
+import javascript from 'highlight.js/lib/languages/javascript'
+import typescript from 'highlight.js/lib/languages/typescript'
+import xml from 'highlight.js/lib/languages/xml'
+import css from 'highlight.js/lib/languages/css'
+import json from 'highlight.js/lib/languages/json'
+import bash from 'highlight.js/lib/languages/bash'
+import python from 'highlight.js/lib/languages/python'
+import go from 'highlight.js/lib/languages/go'
+import rust from 'highlight.js/lib/languages/rust'
+import sql from 'highlight.js/lib/languages/sql'
+import yaml from 'highlight.js/lib/languages/yaml'
+import markdown from 'highlight.js/lib/languages/markdown'
+
+const LANGUAGES = {
+  javascript,
+  typescript,
+  xml,
+  css,
+  json,
+  bash,
+  python,
+  go,
+  rust,
+  sql,
+  yaml,
+  markdown
+}
+
+for (const [name, def] of Object.entries(LANGUAGES)) {
+  hljs.registerLanguage(name, def)
+}
+
+/**
+ * markdown-it `highlight` callback. Returns a full `<pre class="hljs">` block
+ * for a known language; an empty string otherwise so markdown-it falls back to
+ * its own safe escaping.
+ */
+export function highlightCode(code: string, lang: string): string {
+  if (lang && hljs.getLanguage(lang)) {
+    try {
+      const out = hljs.highlight(code, { language: lang, ignoreIllegals: true }).value
+      return `<pre class="hljs"><code>${out}</code></pre>`
+    } catch {
+      /* fall through to default escaping */
+    }
+  }
+  return ''
+}

--- a/app/test/highlight.test.mjs
+++ b/app/test/highlight.test.mjs
@@ -1,0 +1,44 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import { Window } from 'happy-dom'
+import { highlightCode } from '../src/markdown/highlight.ts'
+
+const require = createRequire(import.meta.url)
+const window = new Window()
+const MarkdownIt = require('markdown-it')
+const DOMPurify = require('dompurify')(window)
+
+const md = new MarkdownIt({
+  html: false,
+  linkify: true,
+  breaks: true,
+  highlight: highlightCode
+})
+
+test('highlightCode marks up a known language', () => {
+  const out = highlightCode('const x = 1', 'js')
+  assert.match(out, /class="hljs/)
+  assert.match(out, /hljs-keyword/) // `const`
+})
+
+test('highlightCode returns empty for an unknown language', () => {
+  assert.equal(highlightCode('foo bar', 'no-such-lang'), '')
+})
+
+test('fenced code block renders hljs spans through markdown-it', () => {
+  const html = md.render('```js\nconst x = 1\n```')
+  assert.match(html, /class="hljs/)
+  assert.match(html, /hljs-keyword/)
+})
+
+test('unknown-language fence still renders a code block (no throw)', () => {
+  const html = md.render('```no-such-lang\nfoo\n```')
+  assert.match(html, /<code/)
+})
+
+test('hljs markup survives DOMPurify sanitization', () => {
+  const clean = DOMPurify.sanitize(md.render('```js\nconst x = 1\n```'))
+  assert.match(clean, /class="hljs/)
+  assert.match(clean, /hljs-keyword/)
+})

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@
 | パス | 内容 | ランタイム |
 |---|---|---|
 | `browser/`, `lib/` | **レガシー本体**（Electron 4 + React 16 + Redux + webpack 1、`.cson` ファイル保存）。保守モードで安定化中 | Node 14 |
-| `app/` | **モダンアプリ土台**（Vite + React 19 + TypeScript + CodeMirror 6）。3ペインUXを再現し、実 `.cson` の読込・新規作成・編集の書き戻し保存（オートセーブ）・タグ編集・フォルダ移動・ゴミ箱（移動/復元/完全削除）・全文検索・一覧ソート（更新/作成/タイトル）・KaTeX 数式プレビュー・仮想化リスト・フォルダピッカーに対応。Electron 42 で配布 | Node 22 |
+| `app/` | **モダンアプリ土台**（Vite + React 19 + TypeScript + CodeMirror 6）。3ペインUXを再現し、実 `.cson` の読込・新規作成・編集の書き戻し保存（オートセーブ）・タグ編集・フォルダ移動・ゴミ箱（移動/復元/完全削除）・全文検索・一覧ソート（更新/作成/タイトル）・KaTeX 数式プレビュー・コードのシンタックスハイライト・仮想化リスト・フォルダピッカーに対応。Electron 42 で配布 | Node 22 |
 | `poc/collab-core/` | **共同編集コアの実証**（Yjs + CodeMirror 6 + self-host Hocuspocus + `.cson` スナップショット、device-pairing 認証） | Node 22 |
 | `docs/` | モダナイゼーション設計判断書（スタック選定・脅威モデル・移行ロードマップ、事実検証済み） | — |
 | `.claude/skills/boostnote-modernize` | アーキテクチャ判断・作業方針をまとめた Claude Code スキル | — |


### PR DESCRIPTION
## 概要
プログラマ向けノートアプリの中核機能。プレビューの fenced code を **highlight.js** でハイライトする。

## 変更点
- **markdown/highlight.ts（新規）**: highlight.js **core ＋ 言語サブセット**（js/ts/xml/css/json/bash/python/go/rust/sql/yaml/markdown）を tree-shake 登録（全言語バンドルを回避）。`highlightCode` を markdown-it の `highlight` に渡す。**未知言語は空文字を返し** markdown-it 既定のエスケープにフォールバック。
- **Preview.tsx**: `MarkdownIt` に `highlight` を設定。`github-dark` テーマ CSS を import。
- **DOMPurify 両立**: hljs 出力がサニタイズで除去されないことを **happy-dom 上で実測**。
- **test/highlight.test.mjs（新規）**: 既知/未知言語・fence 描画・**サニタイズ生存**の 5 ケース。
- **deps(dev)**: `highlight.js`。
- **readme.md**: 対応機能に追記。

## バンドルへの影響
- JS は **~22KB(gzip) 増のみ**（サブセット登録で全言語を回避、1,104→1,174KB raw / 374→397KB gzip）。

## 検証
`npm run lint`（**警告ゼロ**）/ `npm run build` / `npm test`（**36 pass**: …+ highlight 5）すべて緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)