### PR TITLE
app: ノートの Markdown エクスポートを追加

### DIFF
--- a/app/electron/main.cjs
+++ b/app/electron/main.cjs
@@ -75,6 +75,24 @@ ipcMain.handle('notes:create', (_event, opts) => {
   }
 })
 
+// Export a note's content to a user-chosen `.md` file.
+ipcMain.handle('notes:export', async (_event, payload) => {
+  try {
+    const { filename, content } = payload || {}
+    const res = await dialog.showSaveDialog({
+      title: 'Markdown としてエクスポート',
+      defaultPath: filename || 'untitled.md',
+      filters: [{ name: 'Markdown', extensions: ['md'] }]
+    })
+    if (res.canceled || !res.filePath) return { ok: false, canceled: true }
+    fs.writeFileSync(res.filePath, String(content ?? ''), 'utf8')
+    return { ok: true, file: res.filePath }
+  } catch (err) {
+    console.error('notes:export failed:', err)
+    return { ok: false, error: String(err) }
+  }
+})
+
 // Permanently delete a note's `.cson` file.
 ipcMain.handle('notes:delete', (_event, key) => {
   try {

--- a/app/electron/preload.cjs
+++ b/app/electron/preload.cjs
@@ -10,5 +10,6 @@ contextBridge.exposeInMainWorld('boostnote', {
   pickStorage: () => ipcRenderer.invoke('notes:pickStorage'),
   saveNote: note => ipcRenderer.invoke('notes:save', note),
   createNote: opts => ipcRenderer.invoke('notes:create', opts),
-  deleteNote: key => ipcRenderer.invoke('notes:delete', key)
+  deleteNote: key => ipcRenderer.invoke('notes:delete', key),
+  exportNote: payload => ipcRenderer.invoke('notes:export', payload)
 })

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -31,6 +31,7 @@ export default function App() {
 
   const canPick = typeof repository.pickStorage === 'function'
   const canCreate = typeof repository.createNote === 'function'
+  const canExport = typeof repository.exportNote === 'function'
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const newNoteRef = useRef<() => void>(() => {})
 
@@ -206,6 +207,16 @@ export default function App() {
     setActiveKey(null) // the note leaves the current view
   }
 
+  async function handleExport() {
+    if (!active || !repository.exportNote) return
+    try {
+      setSaveError(null)
+      await repository.exportNote(active)
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : String(e))
+    }
+  }
+
   async function deleteActiveForever() {
     if (!active || !repository.deleteNote) return
     if (!window.confirm('このノートを完全に削除しますか？元に戻せません。')) return
@@ -303,6 +314,15 @@ export default function App() {
                 >
                   ★
                 </span>
+                {canExport && (
+                  <button
+                    className="head-btn"
+                    onClick={handleExport}
+                    title="Markdown でエクスポート"
+                  >
+                    ⬇ md
+                  </button>
+                )}
                 {repository.saveNote && (
                   <button
                     className="head-btn"

--- a/app/src/data/exportMarkdown.ts
+++ b/app/src/data/exportMarkdown.ts
@@ -1,0 +1,16 @@
+import type { Note } from '../types'
+
+/**
+ * Derive a safe `.md` filename from a note's title: filesystem-reserved
+ * characters are replaced, whitespace is collapsed, length is capped, and an
+ * empty title falls back to `untitled`.
+ */
+export function exportFilename(note: Pick<Note, 'title'>): string {
+  const base = note.title
+    .replace(/[/\\:*?"<>|]/g, '_') // filesystem-reserved characters
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 80)
+    .trim()
+  return `${base || 'untitled'}.md`
+}

--- a/app/src/data/repository.ts
+++ b/app/src/data/repository.ts
@@ -1,5 +1,6 @@
 import type { Note, Storage } from '../types'
 import { sampleNotes, sampleStorages } from './sampleNotes'
+import { exportFilename } from './exportMarkdown'
 
 /**
  * The data-layer seam. The renderer only ever talks to a NotesRepository;
@@ -17,6 +18,8 @@ export interface NotesRepository {
   createNote?(opts: { storage?: string; folder?: string }): Promise<Note>
   /** Permanently delete a note by key. */
   deleteNote?(key: string): Promise<void>
+  /** Export a note's content to a `.md` file (returns false if canceled). */
+  exportNote?(note: Note): Promise<boolean>
 }
 
 // Deterministic (no Math.random) generator so the list reaches realistic
@@ -96,6 +99,15 @@ export function createElectronRepository(): NotesRepository {
     async deleteNote(key) {
       const res = await window.boostnote!.deleteNote(key)
       if (!res.ok) throw new Error(res.error || 'ノートの削除に失敗しました')
+    },
+    async exportNote(note) {
+      const res = await window.boostnote!.exportNote({
+        filename: exportFilename(note),
+        content: note.content
+      })
+      if (res.canceled) return false
+      if (!res.ok) throw new Error(res.error || 'エクスポートに失敗しました')
+      return true
     }
   }
 }

--- a/app/src/electron.d.ts
+++ b/app/src/electron.d.ts
@@ -24,6 +24,13 @@ export interface CreateNoteOptions {
   content?: string
 }
 
+export interface ExportResult {
+  ok: boolean
+  file?: string
+  canceled?: boolean
+  error?: string
+}
+
 // The preload bridge (electron/preload.cjs). Present only when running inside
 // Electron; the browser foundation falls back to the in-memory repository.
 declare global {
@@ -34,6 +41,10 @@ declare global {
       saveNote(note: Note): Promise<SaveResult>
       createNote(opts: CreateNoteOptions): Promise<CreateResult>
       deleteNote(key: string): Promise<SaveResult>
+      exportNote(payload: {
+        filename: string
+        content: string
+      }): Promise<ExportResult>
     }
   }
 }

--- a/app/test/exportMarkdown.test.mjs
+++ b/app/test/exportMarkdown.test.mjs
@@ -1,0 +1,26 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { exportFilename } from '../src/data/exportMarkdown.ts'
+
+test('uses the title as the filename', () => {
+  assert.equal(exportFilename({ title: 'My Note' }), 'My Note.md')
+})
+
+test('replaces filesystem-reserved characters', () => {
+  assert.equal(exportFilename({ title: 'a/b:c*d?e"f<g>h|i' }), 'a_b_c_d_e_f_g_h_i.md')
+})
+
+test('collapses whitespace and trims', () => {
+  assert.equal(exportFilename({ title: '  hello   world  ' }), 'hello world.md')
+})
+
+test('falls back to untitled for an empty/blank title', () => {
+  assert.equal(exportFilename({ title: '' }), 'untitled.md')
+  assert.equal(exportFilename({ title: '   ' }), 'untitled.md')
+})
+
+test('caps very long titles', () => {
+  const name = exportFilename({ title: 'x'.repeat(200) })
+  assert.ok(name.length <= 83) // 80 chars + ".md"
+  assert.ok(name.endsWith('.md'))
+})

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@
 | パス | 内容 | ランタイム |
 |---|---|---|
 | `browser/`, `lib/` | **レガシー本体**（Electron 4 + React 16 + Redux + webpack 1、`.cson` ファイル保存）。保守モードで安定化中 | Node 14 |
-| `app/` | **モダンアプリ土台**（Vite + React 19 + TypeScript + CodeMirror 6）。3ペインUXを再現し、実 `.cson` の読込・新規作成・編集の書き戻し保存（オートセーブ）・タグ編集・フォルダ移動・ゴミ箱（移動/復元/完全削除）・全文検索・一覧ソート（更新/作成/タイトル）・KaTeX 数式プレビュー・コードのシンタックスハイライト・仮想化リスト・フォルダピッカーに対応。Electron 42 で配布 | Node 22 |
+| `app/` | **モダンアプリ土台**（Vite + React 19 + TypeScript + CodeMirror 6）。3ペインUXを再現し、実 `.cson` の読込・新規作成・編集の書き戻し保存（オートセーブ）・タグ編集・フォルダ移動・ゴミ箱（移動/復元/完全削除）・全文検索・一覧ソート（更新/作成/タイトル）・KaTeX 数式プレビュー・コードのシンタックスハイライト・Markdown エクスポート・仮想化リスト・フォルダピッカーに対応。Electron 42 で配布 | Node 22 |
 | `poc/collab-core/` | **共同編集コアの実証**（Yjs + CodeMirror 6 + self-host Hocuspocus + `.cson` スナップショット、device-pairing 認証） | Node 22 |
 | `docs/` | モダナイゼーション設計判断書（スタック選定・脅威モデル・移行ロードマップ、事実検証済み） | — |
 | `.claude/skills/boostnote-modernize` | アーキテクチャ判断・作業方針をまとめた Claude Code スキル | — |


### PR DESCRIPTION
## 概要
廃盤アプリの後継として「**データを外に出せる**」ことは重要。アクティブノートを保存ダイアログ経由で `.md` として書き出す。

## 変更点
- **data/exportMarkdown.ts（新規）**: `exportFilename` 純関数（FS 予約文字を `_` に置換・空白圧縮・80 文字上限・空タイトルは `untitled`）。
- **main.cjs**: `notes:export` IPC（`showSaveDialog` → `writeFileSync`、キャンセル時は `canceled:true`）。
- **preload.cjs / electron.d.ts**: `exportNote` を公開・型付け（`ExportResult`）。
- **repository.ts**: `NotesRepository.exportNote`（任意）。Electron 実装は `exportFilename` でファイル名を作りブリッジへ。**canceled は false 返却、失敗のみ throw**。
- **App.tsx**: 詳細ヘッダに「⬇ md」ボタン（`canExport` 時、ゴミ箱中は非表示）。
- **test/exportMarkdown.test.mjs（新規）**: ファイル名導出の 5 ケース（予約文字・空白・空タイトル・長さ上限）。
- **readme.md**: 対応機能に追記。

## degrade
ブラウザ土台（in-memory）は `exportNote` 未提供＝ボタン非表示で安全に degrade。

## 検証
`npm run lint`（**警告ゼロ**）/ `npm run build` / `npm test`（**41 pass**: …+ exportMarkdown 5）すべて緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ノートを Markdown（.md）ファイルとしてエクスポートできるようになりました。
  * エクスポート時に、ノートのタイトルから安全なファイル名を自動生成します。
  * 詳細画面にエクスポート用のボタンが追加されました。

* **バグ修正**
  * 保存キャンセル時やエラー時に、適切に失敗状態を返すようになりました。

* **テスト**
  * ファイル名生成のルールを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->