### PR TITLE
app: 「ゴミ箱を空にする」一括削除を追加

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -231,6 +231,28 @@ export default function App() {
     }
   }
 
+  async function handleEmptyTrash() {
+    if (!repository.deleteNote) return
+    const trashed = notes.filter(n => n.isTrashed)
+    if (trashed.length === 0) return
+    if (
+      !window.confirm(
+        `ゴミ箱の ${trashed.length} 件を完全に削除しますか？元に戻せません。`
+      )
+    ) {
+      return
+    }
+    try {
+      setSaveError(null)
+      for (const n of trashed) await repository.deleteNote(n.key)
+      const trashedKeys = new Set(trashed.map(n => n.key))
+      setNotes(prev => prev.filter(n => !trashedKeys.has(n.key)))
+      if (active && trashedKeys.has(active.key)) setActiveKey(null)
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : String(e))
+    }
+  }
+
   const activeFolders = active
     ? (storages.find(s => s.key === active.storage)?.folders ?? [])
     : []
@@ -248,6 +270,11 @@ export default function App() {
         selection={selection}
         onSelect={selectView}
         onPickStorage={canPick ? handlePickStorage : undefined}
+        onEmptyTrash={
+          typeof repository.deleteNote === 'function'
+            ? handleEmptyTrash
+            : undefined
+        }
       />
       <NoteList
         notes={visible}

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -7,6 +7,8 @@ interface Props {
   onSelect: (s: Selection) => void
   /** When set (Electron), shows a button to add a real storage folder. */
   onPickStorage?: () => void
+  /** When set (Electron), shows a button to permanently empty the trash. */
+  onEmptyTrash?: () => void
 }
 
 export function Sidebar({
@@ -14,7 +16,8 @@ export function Sidebar({
   notes,
   selection,
   onSelect,
-  onPickStorage
+  onPickStorage,
+  onEmptyTrash
 }: Props) {
   const live = notes.filter(n => !n.isTrashed)
   const counts = {
@@ -53,6 +56,11 @@ export function Sidebar({
         >
           <span>🗑</span> Trash <span className="count">{counts.trashed}</span>
         </div>
+        {onEmptyTrash && counts.trashed > 0 && (
+          <button className="empty-trash" onClick={onEmptyTrash}>
+            ゴミ箱を空にする
+          </button>
+        )}
       </div>
 
       {storages.map(storage => (

--- a/app/src/theme.css
+++ b/app/src/theme.css
@@ -45,6 +45,13 @@ body {
 .side-item.active { background: #31262e; color: #fff; }
 .side-item .count { margin-left: auto; color: var(--muted); font-size: 12px; }
 .side-item .dot { width: 9px; height: 9px; border-radius: 50%; flex: none; }
+.empty-trash {
+  display: block; margin: 2px 12px 4px auto; font: inherit; font-size: 11px;
+  cursor: pointer; color: var(--muted); background: transparent;
+  border: 1px solid var(--border); border-radius: var(--radius); padding: 2px 8px;
+}
+.empty-trash:hover { color: #fff; background: var(--accent); border-color: transparent; }
+
 .side-head {
   display: flex; align-items: center; gap: 6px;
   padding: 10px 14px 4px; color: var(--muted);


### PR DESCRIPTION
## 概要
捨てる導線（ゴミ箱へ移動・1 件ずつ完全削除）はあったが、**一括完全削除**がなかったギャップを補完。

## 変更点
- **Sidebar.tsx**: `onEmptyTrash` プロップを追加。ゴミ箱が非空のとき Trash 行の下に「ゴミ箱を空にする」ボタンを表示。
- **App.tsx**: `handleEmptyTrash`（`confirm` 後に `isTrashed` の全件を `deleteNote`、state からも除去、アクティブが対象なら選択解除）。`deleteNote` 提供時のみ Sidebar に渡す。
- **theme.css**: `.empty-trash` スタイル。

## 検証
`npm run lint`（**警告ゼロ**）/ `npm run build` / `npm test`（**47 pass**）すべて緑。削除ロジックは既存テスト済みの `deleteNote` を再利用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)