### PR TITLE
app: キーボードショートカットのヘルプオーバーレイ

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -7,6 +7,7 @@ import { NoteList } from './components/NoteList'
 import { MarkdownEditor } from './components/MarkdownEditor'
 import { Preview } from './components/Preview'
 import { TagEditor } from './components/TagEditor'
+import { ShortcutHelp } from './components/ShortcutHelp'
 
 function firstTitle(content: string, fallback: string) {
   const line = content.split('\n').find(l => l.trim().length > 0)
@@ -28,6 +29,7 @@ export default function App() {
   const [pickError, setPickError] = useState<string | null>(null)
   const [query, setQuery] = useState('')
   const [saveError, setSaveError] = useState<string | null>(null)
+  const [showHelp, setShowHelp] = useState(false)
 
   const canPick = typeof repository.pickStorage === 'function'
   const canCreate = typeof repository.createNote === 'function'
@@ -275,6 +277,7 @@ export default function App() {
             ? handleEmptyTrash
             : undefined
         }
+        onShowHelp={() => setShowHelp(true)}
       />
       <NoteList
         notes={visible}
@@ -412,6 +415,7 @@ export default function App() {
           )}
         </div>
       )}
+      <ShortcutHelp open={showHelp} onClose={() => setShowHelp(false)} />
     </div>
   )
 }

--- a/app/src/components/ShortcutHelp.tsx
+++ b/app/src/components/ShortcutHelp.tsx
@@ -1,0 +1,53 @@
+import { useEffect } from 'react'
+
+/** Keyboard shortcuts shown in the in-app help overlay (mirrors the README). */
+const SHORTCUTS: { keys: string; desc: string }[] = [
+  { keys: '⌘/Ctrl + N', desc: '新規ノート' },
+  { keys: '⌘/Ctrl + F', desc: '検索にフォーカス' },
+  { keys: '⌘/Ctrl + B', desc: '太字（選択をトグル）' },
+  { keys: '⌘/Ctrl + I', desc: '斜体（選択をトグル）' },
+  { keys: '⌘/Ctrl + K', desc: 'リンク化' },
+  { keys: 'Esc', desc: 'このヘルプを閉じる' }
+]
+
+interface Props {
+  open: boolean
+  onClose: () => void
+}
+
+/** Modal overlay listing keyboard shortcuts. Closes on Esc or backdrop click. */
+export function ShortcutHelp({ open, onClose }: Props) {
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return (
+    <div className="overlay" onClick={onClose}>
+      <div
+        className="overlay-card"
+        role="dialog"
+        aria-label="キーボードショートカット"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="overlay-title">キーボードショートカット</div>
+        <table className="shortcut-table">
+          <tbody>
+            {SHORTCUTS.map(s => (
+              <tr key={s.keys}>
+                <td className="shortcut-keys">{s.keys}</td>
+                <td>{s.desc}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -9,6 +9,8 @@ interface Props {
   onPickStorage?: () => void
   /** When set (Electron), shows a button to permanently empty the trash. */
   onEmptyTrash?: () => void
+  /** Opens the keyboard-shortcut help overlay. */
+  onShowHelp?: () => void
 }
 
 export function Sidebar({
@@ -17,7 +19,8 @@ export function Sidebar({
   selection,
   onSelect,
   onPickStorage,
-  onEmptyTrash
+  onEmptyTrash,
+  onShowHelp
 }: Props) {
   const live = notes.filter(n => !n.isTrashed)
   const counts = {
@@ -100,11 +103,18 @@ export function Sidebar({
         </div>
       )}
 
-      {onPickStorage && (
+      {(onPickStorage || onShowHelp) && (
         <div className="side-section" style={{ marginTop: 'auto' }}>
-          <button className="btn-ghost" onClick={onPickStorage}>
-            ＋ ストレージを追加
-          </button>
+          {onPickStorage && (
+            <button className="btn-ghost" onClick={onPickStorage}>
+              ＋ ストレージを追加
+            </button>
+          )}
+          {onShowHelp && (
+            <button className="btn-ghost" onClick={onShowHelp}>
+              ⌨ ショートカット
+            </button>
+          )}
         </div>
       )}
     </nav>

--- a/app/src/theme.css
+++ b/app/src/theme.css
@@ -181,3 +181,22 @@ body {
 .btn-primary:hover { filter: brightness(1.08); }
 .btn-ghost { background: transparent; color: var(--muted); width: 100%; }
 .btn-ghost:hover { background: #2a2e36; color: var(--fg); }
+
+/* ---- Overlay / modal -------------------------------------------------- */
+.overlay {
+  position: fixed; inset: 0; z-index: 100;
+  background: rgba(0, 0, 0, 0.5);
+  display: grid; place-items: center;
+}
+.overlay-card {
+  background: var(--bg-elev); border: 1px solid var(--border);
+  border-radius: 8px; padding: 18px 22px; min-width: 320px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+}
+.overlay-title { font-weight: 600; margin-bottom: 12px; }
+.shortcut-table { border-collapse: collapse; width: 100%; }
+.shortcut-table td { padding: 5px 10px 5px 0; color: var(--fg); }
+.shortcut-keys {
+  font-family: 'SFMono-Regular', Menlo, monospace; color: var(--muted);
+  white-space: nowrap; padding-right: 18px !important;
+}


### PR DESCRIPTION
## 概要
追加済みのショートカット（⌘N/F/B/I/K）を**アプリ内で発見可能**にするヘルプオーバーレイ。

## 変更点
- **components/ShortcutHelp.tsx（新規）**: モーダルオーバーレイ。**Esc／背景クリック**で閉じる。`role="dialog"`。一覧は README と同期。
- **Sidebar.tsx**: フッターに「⌨ ショートカット」ボタン（`onShowHelp`）。ストレージ追加ボタンと同じ下部セクションに集約。
- **App.tsx**: `showHelp` state ＋ オーバーレイ描画。
- **theme.css**: `.overlay` / `.overlay-card` / `.shortcut-table` スタイル。

## 設計メモ
エディタとのキー衝突を避けるため、起動は `?` キーではなく**ボタン＋Esc**。

## 検証
`npm run lint`（**警告ゼロ**）/ `npm run build` / `npm test`（**47 pass**）すべて緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)