### PR TITLE
rebrand: アプリシェルの識別子を The Boosters に（Phase 1）

### DIFF
--- a/lib/main-menu.js
+++ b/lib/main-menu.js
@@ -11,10 +11,10 @@ const LINUX = process.platform === 'linux'
 
 const boost = macOS
   ? {
-      label: 'Boostnote',
+      label: 'The Boosters',
       submenu: [
         {
-          label: 'About Boostnote',
+          label: 'About The Boosters',
           selector: 'orderFrontStandardAboutPanel:'
         },
         {
@@ -31,7 +31,7 @@ const boost = macOS
           type: 'separator'
         },
         {
-          label: 'Hide Boostnote',
+          label: 'Hide The Boosters',
           accelerator: 'Command+H',
           selector: 'hide:'
         },
@@ -48,14 +48,14 @@ const boost = macOS
           type: 'separator'
         },
         {
-          label: 'Quit Boostnote',
+          label: 'Quit The Boosters',
           role: 'quit',
           accelerator: 'CommandOrControl+Q'
         }
       ]
     }
   : {
-      label: 'Boostnote',
+      label: 'The Boosters',
       submenu: [
         {
           label: 'Preferences',
@@ -404,27 +404,27 @@ const help = {
   role: 'help',
   submenu: [
     {
-      label: 'Boostnote official site',
+      label: 'The Boosters site',
       click() {
-        shell.openExternal('https://boostnote.io/')
+        shell.openExternal('https://github.com/BoxPistols/TheBoosters')
       }
     },
     {
       label: 'Wiki',
       click() {
-        shell.openExternal('https://github.com/BoostIO/Boostnote/wiki')
+        shell.openExternal('https://github.com/BoxPistols/TheBoosters/wiki')
       }
     },
     {
       label: 'Issue Tracker',
       click() {
-        shell.openExternal('https://github.com/BoostIO/Boostnote/issues')
+        shell.openExternal('https://github.com/BoxPistols/TheBoosters/issues')
       }
     },
     {
       label: 'Changelog',
       click() {
-        shell.openExternal('https://github.com/BoostIO/boost-releases')
+        shell.openExternal('https://github.com/BoxPistols/TheBoosters/releases')
       }
     },
     {
@@ -474,8 +474,8 @@ const help = {
         const OSInfo = `${os.type()} ${os.arch()} ${os.release()}`
         const detail = `Version: ${version}\nElectron: ${electronVersion}\nChrome: ${chromeVersion}\nNode.js: ${nodeVersion}\nV8: ${v8Version}\nOS: ${OSInfo}`
         electron.dialog.showMessageBox(BrowserWindow.getFocusedWindow(), {
-          title: 'BoostNote',
-          message: 'BoostNote',
+          title: 'The Boosters',
+          message: 'The Boosters',
           type: 'info',
           detail: `\n${detail}`
         })

--- a/lib/main.development.html
+++ b/lib/main.development.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="../node_modules/codemirror/addon/lint/lint.css">
   <link rel="stylesheet" href="../extra_scripts/codemirror/mode/bfm/bfm.css">
 
-  <title>Boostnote</title>
+  <title>The Boosters</title>
 
   <style>
     @font-face {

--- a/lib/main.production.html
+++ b/lib/main.production.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="../node_modules/codemirror/addon/lint/lint.css">
   <link rel="stylesheet" href="../extra_scripts/codemirror/mode/bfm/bfm.css">
 
-  <title>Boostnote</title>
+  <title>The Boosters</title>
 
   <style>
     @font-face {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "boost",
-  "productName": "Boostnote",
+  "name": "the-boosters",
+  "productName": "The Boosters",
   "version": "0.16.1",
   "main": "index.js",
-  "description": "Boostnote",
+  "description": "The Boosters — a modernized, independent successor to Boostnote (originally © BoostIO, GPL-3.0)",
   "license": "GPL-3.0",
   "scripts": {
     "start": "electron ./index.js",
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/BoostIO/Boostnote.git"
+    "url": "git+https://github.com/BoxPistols/TheBoosters.git"
   },
   "keywords": [
     "boostnote",


### PR DESCRIPTION
## 概要
独立化（`BoxPistols/TheBoosters`、fork 切離し済み）に伴い、**レガシー本体**（正本＝全機能版）の表示・識別名を Boostnote → **The Boosters** に。Phase 1 はアプリシェル（OSに見える名前）。

## 変更
- **package.json**: `name` boost→the-boosters / `productName` Boostnote→The Boosters / `description` に「Boostnote（© BoostIO, GPL-3.0）の独立後継」と帰属明記 / `repository.url` を BoxPistols/TheBoosters へ修正。**license GPL-3.0 は維持**。
- **lib/main.{development,production}.html**: `<title>` を The Boosters に（ウィンドウタイトル）。
- **lib/main-menu.js**: アプリメニュー（About / Hide / Quit / メニュー名）・About ダイアログ・Help の各 URL（公式/Wiki/Issue/Changelog）を The Boosters / BoxPistols/TheBoosters へ。

## 温存（意図的に変更なし）
`boostnote.json`・`.cson`・`.boostnoterc`（**データ/設定形式** → 既存ノート互換のため）、BoostIO/GPL **ライセンス帰属**、third-party の Boostnote markdown cheatsheet リンク。

## 次PR
i18n（locales 260行・value 側）と通知文言を i18n-aware に別PRで対応。

## 検証
package.json JSON 妥当 / `eslint lib/main-menu.js` クリーン。（GUI起動確認は要実機）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * アプリ内の表記を「Boostnote」から「The Boosters」へ統一しました。
  * ヘルプやアバウト画面の案内先も新しい公式サイト関連リンクに更新しました。
* **その他**
  * アプリ名、製品名、説明文、ウィンドウタイトルを新名称に合わせて変更しました。
  * メニュー項目の表示名（About / Hide / Quit など）も新ブランドに合わせて更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->