### PR TITLE
fix(modal): 設定モーダルが開かない問題を修正（Vite ビルドで CSS クラス名不一致）

### DIFF
--- a/browser/main/NoteList/index.js
+++ b/browser/main/NoteList/index.js
@@ -1259,6 +1259,7 @@ class NoteList extends React.Component {
         <div
           styleName='list'
           ref='list'
+          data-note-list
           tabIndex='-1'
           onKeyDown={e => this.handleNoteListKeyDown(e)}
           onKeyUp={this.handleNoteListKeyUp}

--- a/browser/main/lib/modal.js
+++ b/browser/main/lib/modal.js
@@ -3,6 +3,15 @@ import { Provider } from 'react-redux'
 import ReactDOM from 'react-dom'
 import { store } from '../store'
 
+// CSS-module class names differ per bundler (the old webpack selector
+// '.NoteList__list___…' matches nothing under Vite), so locate NoteList's
+// scroller by a stable data attribute — and never let a missing element
+// block opening/closing the modal.
+function setNoteListOverflow(value) {
+  const list = document.querySelector('[data-note-list]')
+  if (list != null) list.style.overflow = value
+}
+
 class ModalBase extends React.Component {
   constructor(props) {
     super(props)
@@ -20,11 +29,7 @@ class ModalBase extends React.Component {
         componentProps: null,
         isHidden: true
       })
-    // Toggle overflow style on NoteList
-    const list = document.querySelector(
-      '.NoteList__list___browser-main-NoteList-'
-    )
-    list.style.overflow = 'auto'
+    setNoteListOverflow('auto')
   }
 
   render() {
@@ -54,10 +59,7 @@ export function openModal(component, props) {
     return
   }
   // Hide scrollbar by removing overflow when modal opens
-  const list = document.querySelector(
-    '.NoteList__list___browser-main-NoteList-'
-  )
-  list.style.overflow = 'hidden'
+  setNoteListOverflow('hidden')
   document.body.setAttribute('data-modal', 'open')
   modalBase.setState({
     component: component,

--- a/tests/lib/modal.test.js
+++ b/tests/lib/modal.test.js
@@ -1,0 +1,66 @@
+/**
+ * Event-handling regression tests for the modal system.
+ *
+ * The Preferences modal silently failed to open when openModal() threw on a
+ * missing NoteList element: the webpack-era CSS-module selector
+ * ('.NoteList__list___browser-main-NoteList-') matches nothing under the
+ * Vite build, so `null.style` aborted the handler before setState ran.
+ * These tests pin the null-safe behaviour and the stable data-attribute
+ * lookup that replaced it.
+ */
+import React from 'react'
+
+jest.mock('../../browser/main/store', () => ({
+  store: {
+    getState: () => ({}),
+    subscribe: () => () => {},
+    dispatch: () => {}
+  }
+}))
+
+const modal = require('../../browser/main/lib/modal')
+const { openModal, closeModal, isModalOpen } = modal
+
+const Dummy = () => React.createElement('div', { id: 'dummy-modal-content' })
+
+afterEach(() => {
+  closeModal()
+  const list = document.querySelector('[data-note-list]')
+  if (list != null) list.remove()
+})
+
+it('openModal opens the modal even when the NoteList element is absent', () => {
+  expect(document.querySelector('[data-note-list]')).toBeNull()
+  expect(() => openModal(Dummy)).not.toThrow()
+  expect(isModalOpen()).toBe(true)
+  expect(document.querySelector('.ModalBase').className).not.toMatch(/hide/)
+  expect(document.querySelector('#dummy-modal-content')).not.toBeNull()
+})
+
+it('closeModal closes without throwing when the NoteList element is absent', () => {
+  openModal(Dummy)
+  expect(() => closeModal()).not.toThrow()
+  expect(isModalOpen()).toBe(false)
+  expect(document.querySelector('.ModalBase').className).toMatch(/hide/)
+})
+
+it('toggles NoteList overflow via the data attribute when present', () => {
+  const list = document.createElement('div')
+  list.setAttribute('data-note-list', '')
+  document.body.appendChild(list)
+  openModal(Dummy)
+  expect(list.style.overflow).toBe('hidden')
+  closeModal()
+  expect(list.style.overflow).toBe('auto')
+})
+
+it('marks body with data-modal=open while open', () => {
+  openModal(Dummy)
+  expect(document.body.getAttribute('data-modal')).toBe('open')
+})
+
+it('default export exposes open/close/isOpen', () => {
+  expect(modal.default.open).toBe(openModal)
+  expect(modal.default.close).toBe(closeModal)
+  expect(modal.default.isOpen).toBe(isModalOpen)
+})


### PR DESCRIPTION
## 問題
Vite 移行後、設定画面が一切開かなくなっていた（サイドバー「…」ボタンも Cmd+, も無反応）。

## 根本原因
`browser/main/lib/modal.js` の `openModal()` / `close()` が webpack 時代の CSS Modules クラス名 `.NoteList__list___browser-main-NoteList-` をハードコードして `querySelector` していた。Vite のスコープ名は別形式（`compiled/main.css` に "NoteList" という文字列は存在しない）ため `null.style.overflow` で throw し、`modalBase.setState` に到達する前にハンドラが中断していた。

## 修正
- NoteList のスクロール要素に安定属性 `data-note-list` を付与（バンドラ非依存）
- `modal.js` に null ガード付きヘルパ `setNoteListOverflow()` を導入。要素が見つからなくてもモーダルの開閉は必ず成立する
- イベントハンドリング回帰テスト `tests/lib/modal.test.js` を追加（5 件）
  - NoteList 要素欠如時に openModal / closeModal が throw しない
  - モーダルの表示/非表示状態
  - `data-note-list` 経由の overflow トグル
  - `data-modal` body 属性

## 検証
- `jest tests/lib/modal.test.js`: 5 passed
- フルテスト: 239 passed / 4 skipped
- `pnpm run lint`: 0 errors（警告 6 件は既存）
- `pnpm run compile`: バンドルに `data-note-list` 反映・旧セレクタ消滅を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * モーダル表示時に、関連リストのスクロールを自動的に制御するようになりました。
  * 対象要素を識別しやすくする属性が追加されました。

* **バグ修正**
  * 対象要素がない場合でも、モーダルの開閉処理がエラーにならないよう改善しました。
  * モーダルの開閉に応じて、スクロール制御が正しく切り替わるようになりました。

* **テスト**
  * モーダルの開閉動作とスクロール制御を確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->