### PR TITLE
fix(detail): InfoPanel のノートリンクがノート遷移後も更新されない問題を修正

### DIFF
--- a/browser/main/Detail/InfoPanel.js
+++ b/browser/main/Detail/InfoPanel.js
@@ -79,7 +79,10 @@ class InfoPanel extends React.Component {
           <input
             styleName='infoPanel-noteLink'
             ref='noteLink'
-            defaultValue={noteLink}
+            // defaultValue only applies at mount, so the link stayed stuck on
+            // the first-opened note after navigation — keep it controlled.
+            value={noteLink}
+            readOnly
             onClick={e => {
               e.target.select()
             }}

--- a/tests/components/InfoPanel.test.js
+++ b/tests/components/InfoPanel.test.js
@@ -1,0 +1,46 @@
+/**
+ * Regression test: the NOTE LINK input used `defaultValue`, which only
+ * applies at mount — after navigating to another note the panel kept
+ * showing the first-opened note's link. The input must track the
+ * `noteLink` prop as a controlled value.
+ */
+import React from 'react'
+import ReactDOM from 'react-dom'
+import InfoPanel from 'browser/main/Detail/InfoPanel'
+
+const baseProps = {
+  storageName: 'My Storage',
+  folderName: 'My Folder',
+  updatedAt: '2026-07-05 00:00',
+  createdAt: '2026-07-01 00:00',
+  exportAsMd: jest.fn(),
+  exportAsTxt: jest.fn(),
+  exportAsHtml: jest.fn(),
+  exportAsPdf: jest.fn(),
+  wordCount: 1,
+  letterCount: 1,
+  type: 'MARKDOWN_NOTE',
+  print: jest.fn()
+}
+
+it('note link input tracks the noteLink prop across note navigation', () => {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+
+  ReactDOM.render(
+    <InfoPanel {...baseProps} noteLink='[Theme Update](:note:aaaa-1111)' />,
+    container
+  )
+  const input = container.querySelector('input')
+  expect(input.value).toBe('[Theme Update](:note:aaaa-1111)')
+
+  // simulate navigating to another note: same mounted panel, new prop
+  ReactDOM.render(
+    <InfoPanel {...baseProps} noteLink='[Other Note](:note:bbbb-2222)' />,
+    container
+  )
+  expect(input.value).toBe('[Other Note](:note:bbbb-2222)')
+
+  ReactDOM.unmountComponentAtNode(container)
+  container.remove()
+})


### PR DESCRIPTION
## 問題
Info パネルの NOTE LINK（`[Title](:note:key)`）が、別ノートへ遷移しても最初に開いたノートのリンクのまま固定されていた。

## 原因
`<input defaultValue={noteLink}>` — `defaultValue` はマウント時に一度だけ適用されるため、props 更新に追従しない（非制御 input のバインド不備）。

## 修正
- `value={noteLink}` + `readOnly` の制御コンポーネントに変更（クリック選択・コピーは従来通り）
- ノート遷移をシミュレートする回帰テスト `tests/components/InfoPanel.test.js` を追加（修正前の実装では fail する）

## 検証
- 新テスト pass / フルスイート 240 passed / lint 0 errors / `pnpm run compile` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)