### PR TITLE
feat(theme): 'Rockabilly' カラーテーマ追加（The Boosters ブランドテーマ）

### DIFF
--- a/browser/lib/ui-themes.js
+++ b/browser/lib/ui-themes.js
@@ -27,6 +27,11 @@ export default [
     isDark: true
   },
   {
+    name: 'rockabilly',
+    label: i18n.__('Rockabilly'),
+    isDark: true
+  },
+  {
     name: 'solarized-dark',
     label: i18n.__('Solarized Dark'),
     isDark: true

--- a/browser/styles/index.styl
+++ b/browser/styles/index.styl
@@ -455,6 +455,37 @@ $ui-vulcan-table-even-backgroundColor = darken($ui-vulcan-noteDetail-backgroundC
 $ui-vulcan-table-head-backgroundColor = $ui-vulcan-table-even-backgroundColor
 $ui-vulcan-table-borderColor = lighten(darken(#21252B, 10%), 20%)
 
+/******* Rockabilly theme ********/
+// The Boosters brand theme (docs/UI-CONCEPT-classic-rock.md, direction A):
+// warm charcoal stage, vintage cream text, vermilion accent, tube amber hover.
+$ui-rockabilly-backgroundColor = #1C1A17
+$ui-rockabilly-noteList-backgroundColor = #26231F
+$ui-rockabilly-noteDetail-backgroundColor = #1C1A17
+$ui-rockabilly-tagList-backgroundColor = #F2E8D5
+
+$ui-rockabilly-text-color = #F2E8D5
+$ui-rockabilly-inactive-text-color = #8C8577
+$ui-rockabilly-active-color = #D7263D
+
+$ui-rockabilly-borderColor = #33302A
+
+$ui-rockabilly-tag-backgroundColor = #33302A
+
+$ui-rockabilly-button-backgroundColor = #2C2925
+$ui-rockabilly-button--active-color = #F2E8D5
+$ui-rockabilly-button--active-backgroundColor = #D7263D
+$ui-rockabilly-button--hover-color = #E8A33D
+$ui-rockabilly-button--hover-backgroundColor = lighten($ui-rockabilly-backgroundColor, 10%)
+$ui-rockabilly-button--focus-borderColor = lighten(#D7263D, 25%)
+
+$ui-rockabilly-kbd-backgroundColor = #14120F
+$ui-rockabilly-kbd-color = $ui-rockabilly-text-color
+
+$ui-rockabilly-table-odd-backgroundColor = $ui-rockabilly-noteDetail-backgroundColor
+$ui-rockabilly-table-even-backgroundColor = darken($ui-rockabilly-noteDetail-backgroundColor, 10%)
+$ui-rockabilly-table-head-backgroundColor = $ui-rockabilly-table-even-backgroundColor
+$ui-rockabilly-table-borderColor = #3D3831
+
 
 
 debug-theme-var(theme, suffix)
@@ -463,4 +494,4 @@ debug-theme-var(theme, suffix)
 get-theme-var(theme, suffix)
   lookup('$ui-' + theme + '-' + suffix)
 
-$themes = 'monokai' 'nord' 'vulcan'
+$themes = 'monokai' 'nord' 'vulcan' 'rockabilly'

--- a/docs/UI-CONCEPT-classic-rock.md
+++ b/docs/UI-CONCEPT-classic-rock.md
@@ -1,6 +1,9 @@
 # The Boosters — UI コンセプト「クラシックロック」
 
-Status: Proposal (2026-07-05) / Owner: BoxPistols
+Status: **A 採用（カラーのみ）** (2026-07-05) / Owner: BoxPistols
+決定: カラー設計は A で確定。極端なコンセプト転換は行わない —— レトロフォント・
+レコード/チケット/VU メーター等のモチーフ演出（Phase 3）は見送り。
+実装: `ui.theme = 'rockabilly'`（browser/styles/index.styl + ui-themes.js）
 関連: docs/NEXT-STEPS-2026-06.md, .claude/skills/boostnote-modernize
 
 ## ねらい


### PR DESCRIPTION
## 概要
コンセプト A「Vintage Stage」の**カラーのみ**を実装（決定事項: 極端なコンセプト転換はしない。レトロフォント・モチーフ演出は見送り）。

## 内容
- 新テーマ `rockabilly`: ウォームチャコール `#1C1A17` ＋ ヴィンテージクリーム `#F2E8D5` ＋ バーミリオン `#D7263D`（アクセント）＋ 真空管アンバー `#E8A33D`（ホバー）
- 既存テーマ機構への**追加のみ**: `$themes` リスト + `ui-themes.js` 登録で、38 ファイルのテーマループと Markdown プレビュー（iframe の data-theme）に自動適用。既存テーマは無変更
- 設定 > インターフェース > テーマに「Rockabilly」が自動で出現。デフォルトテーマは変えていないので、有効化は任意選択

## 検証
- lint 0 errors / テスト 240 passed / compile OK（生成 CSS に rockabilly セレクタ 360 箇所を確認）

## 使い方
設定 (Cmd+,) → インターフェース → テーマ → Rockabilly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 新しいテーマ「Rockabilly」が追加され、テーマ切り替えで選べるようになりました。
  * ダーク系の配色として、背景・文字・タグ・ボタン・テーブルなどの見た目が新しく適用されます。

* **ドキュメント**
  * UI コンセプト資料の状態が更新され、Rockabilly の採用方針が明確になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->