### PR TITLE
fix(theme): Rockabilly のベース面をニュートラル化（視認性改善）

### DIFF
--- a/browser/styles/index.styl
+++ b/browser/styles/index.styl
@@ -456,35 +456,37 @@ $ui-vulcan-table-head-backgroundColor = $ui-vulcan-table-even-backgroundColor
 $ui-vulcan-table-borderColor = lighten(darken(#21252B, 10%), 20%)
 
 /******* Rockabilly theme ********/
-// The Boosters brand theme (docs/UI-CONCEPT-classic-rock.md, direction A):
-// warm charcoal stage, vintage cream text, vermilion accent, tube amber hover.
-$ui-rockabilly-backgroundColor = #1C1A17
-$ui-rockabilly-noteList-backgroundColor = #26231F
-$ui-rockabilly-noteDetail-backgroundColor = #1C1A17
-$ui-rockabilly-tagList-backgroundColor = #F2E8D5
+// The Boosters brand theme (docs/UI-CONCEPT-classic-rock.md, direction A).
+// 2026-07 revision: the sepia/warm base hurt readability, so the surfaces
+// are neutral charcoal now — the identity lives only in the vermilion
+// accent and tube-amber hover. All pairs measured >= WCAG AA.
+$ui-rockabilly-backgroundColor = #1C1C1E
+$ui-rockabilly-noteList-backgroundColor = #242426
+$ui-rockabilly-noteDetail-backgroundColor = #1C1C1E
+$ui-rockabilly-tagList-backgroundColor = #ECECEC
 
-$ui-rockabilly-text-color = #F2E8D5
-$ui-rockabilly-inactive-text-color = #8C8577
+$ui-rockabilly-text-color = #EAEAEA
+$ui-rockabilly-inactive-text-color = #9A9A9E
 $ui-rockabilly-active-color = #D7263D
 
-$ui-rockabilly-borderColor = #33302A
+$ui-rockabilly-borderColor = #333336
 
-$ui-rockabilly-tag-backgroundColor = #33302A
+$ui-rockabilly-tag-backgroundColor = #333336
 
-$ui-rockabilly-button-backgroundColor = #2C2925
-$ui-rockabilly-button--active-color = #F2E8D5
+$ui-rockabilly-button-backgroundColor = #2A2A2D
+$ui-rockabilly-button--active-color = #FFFFFF
 $ui-rockabilly-button--active-backgroundColor = #D7263D
 $ui-rockabilly-button--hover-color = #E8A33D
 $ui-rockabilly-button--hover-backgroundColor = lighten($ui-rockabilly-backgroundColor, 10%)
 $ui-rockabilly-button--focus-borderColor = lighten(#D7263D, 25%)
 
-$ui-rockabilly-kbd-backgroundColor = #14120F
+$ui-rockabilly-kbd-backgroundColor = #141416
 $ui-rockabilly-kbd-color = $ui-rockabilly-text-color
 
 $ui-rockabilly-table-odd-backgroundColor = $ui-rockabilly-noteDetail-backgroundColor
 $ui-rockabilly-table-even-backgroundColor = darken($ui-rockabilly-noteDetail-backgroundColor, 10%)
 $ui-rockabilly-table-head-backgroundColor = $ui-rockabilly-table-even-backgroundColor
-$ui-rockabilly-table-borderColor = #3D3831
+$ui-rockabilly-table-borderColor = #38383B
 
 
 

--- a/docs/UI-CONCEPT-classic-rock.md
+++ b/docs/UI-CONCEPT-classic-rock.md
@@ -4,6 +4,10 @@ Status: **A 採用（カラーのみ）** (2026-07-05) / Owner: BoxPistols
 決定: カラー設計は A で確定。極端なコンセプト転換は行わない —— レトロフォント・
 レコード/チケット/VU メーター等のモチーフ演出（Phase 3）は見送り。
 実装: `ui.theme = 'rockabilly'`（browser/styles/index.styl + ui-themes.js）
+改訂 (2026-07-05): セピア/暖色のオーバーレイは視認性を損ねるとの指摘により、
+ベース面をニュートラルチャコール（#1C1C1E / #242426、文字 #EAEAEA）へ変更。
+ブランドはバーミリオン #D7263D とアンバー #E8A33D のアクセントのみで表現。
+全ペア WCAG AA 実測済み（本文 14.1 : 1、非活性 6.1 : 1、アクセント上白 4.96 : 1）。
 関連: docs/NEXT-STEPS-2026-06.md, .claude/skills/boostnote-modernize
 
 ## ねらい


### PR DESCRIPTION
## フィードバック対応
「セピア系・暖色系のオーバーレイは視認性を損ねる」→ ベース面から暖色を除去。

## 変更
- 背景/パネル/ボタン面: ウォームチャコール → **ニュートラルチャコール** (`#1C1C1E` / `#242426` / `#2A2A2D`)
- テキスト: ヴィンテージクリーム `#F2E8D5` → **ニュートラル** `#EAEAEA`（非活性 `#9A9A9E`）
- ブランド表現は**アクセントのみ**に限定: バーミリオン `#D7263D`（選択）+ 真空管アンバー `#E8A33D`（ホバー）は維持

## コントラスト実測（WCAG）
| ペア | 比 | 判定 |
|---|---|---|
| 本文 #EAEAEA / 背景 #1C1C1E | 14.1:1 | AAA |
| 本文 / パネル #242426 | 12.9:1 | AAA |
| 非活性 #9A9A9E / 背景 | 6.1:1 | AA |
| 白 / アクセント #D7263D | 4.96:1 | AA |
| アンバー #E8A33D / 背景 | 7.9:1 | AAA |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * Rockabillyテーマの配色を更新し、サーフェスをよりニュートラルなチャコール基調に調整しました。
  * ホバー、フォーカス、タグ、境界線などのUIカラーを見直し、全体の見え方を統一しました。

* **ドキュメント**
  * カラーパレットの方針変更と、主要な配色の視認性基準を追記しました。
  * アクセントカラーの扱いについて、最新のデザイン意図を反映しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->