### PR TITLE
feat(dist): mac deep ad-hoc 署名（ターミナル不要化）＋ Windows 実起動スモーク CI

### DIFF
--- a/.github/workflows/win-smoke.yml
+++ b/.github/workflows/win-smoke.yml
@@ -1,0 +1,91 @@
+# Windows 実起動スモークテスト:
+# リリース済みの NSIS インストーラを windows ランナーでサイレントインストールし、
+# 実際にアプリを起動して renderer がメイン UI まで到達したかを DOM プローブで
+# 機械検証する。「ビルドは通るが実機で splash 停止」(v0.16.2/0.16.3) の再発防止。
+name: win-smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'テストするリリースタグ (例: v0.16.4)'
+        required: true
+        default: 'v0.16.4'
+
+jobs:
+  smoke:
+    runs-on: windows-latest
+    timeout-minutes: 15
+    env:
+      RELEASE_TAG: ${{ inputs.tag }}
+    steps:
+      - name: Download installer from release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download $env:RELEASE_TAG --repo ${{ github.repository }} --pattern "The-Boosters-Setup-*.exe" --dir .
+          Get-ChildItem "The-Boosters-Setup-*.exe"
+
+      - name: Silent install (NSIS /S)
+        shell: pwsh
+        run: |
+          $setup = Get-ChildItem "The-Boosters-Setup-*.exe" | Select-Object -First 1
+          Start-Process -FilePath $setup.FullName -ArgumentList "/S" -Wait
+          Start-Sleep -Seconds 5
+
+      - name: Locate install dir and inject DOM probe
+        shell: pwsh
+        run: |
+          $candidates = @(
+            (Join-Path $env:LOCALAPPDATA "Programs\the-boosters"),
+            (Join-Path $env:LOCALAPPDATA "Programs\The Boosters")
+          )
+          $appDir = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+          if (-not $appDir) {
+            Get-ChildItem (Join-Path $env:LOCALAPPDATA "Programs")
+            throw "install dir not found"
+          }
+          Write-Host "APPDIR=$appDir"
+          "APPDIR=$appDir" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+          $idx = Join-Path $appDir "resources\app\index.js"
+          $probe = @'
+          const { app: probeApp } = require('electron')
+          const probeFs = require('fs')
+          const probeOut = require('path').join(require('os').tmpdir(), 'tb-verify-result.json')
+          probeApp.on('web-contents-created', (_e, wc) => {
+            wc.on('did-finish-load', () => {
+              setTimeout(() => {
+                wc.executeJavaScript('({cover: !!document.getElementById("loadingCover"), content: document.getElementById("content") ? document.getElementById("content").children.length : -1, sidenav: !!document.querySelector("[class*=SideNav]")})')
+                  .then(r => probeFs.writeFileSync(probeOut, JSON.stringify(r)))
+                  .catch(e => probeFs.writeFileSync(probeOut, 'ERR ' + e.message))
+              }, 10000)
+            })
+          })
+          '@
+          $orig = Get-Content -Raw $idx
+          Set-Content -Path $idx -Value ($probe + "`n" + $orig) -Encoding utf8
+
+      - name: Launch app and assert main UI reached
+        shell: pwsh
+        run: |
+          $exe = Join-Path $env:APPDIR "The Boosters.exe"
+          $proc = Start-Process -FilePath $exe -PassThru
+          $result = Join-Path $env:TEMP "tb-verify-result.json"
+          $deadline = (Get-Date).AddSeconds(90)
+          while (-not (Test-Path $result) -and (Get-Date) -lt $deadline) {
+            Start-Sleep -Seconds 3
+          }
+          Get-Process -Name "The Boosters" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+
+          if (-not (Test-Path $result)) {
+            throw "probe result not produced — app never reached did-finish-load"
+          }
+          $json = Get-Content -Raw $result
+          Write-Host "PROBE: $json"
+          $obj = $json | ConvertFrom-Json
+          if (($obj.cover -ne $false) -or ($obj.content -lt 1)) {
+            throw "renderer did not reach the main UI: $json"
+          }
+          Write-Host "WINDOWS SMOKE TEST PASSED"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "productName": "The Boosters",
     "copyright": "GPL-3.0, inherited from BoostIO (Boostnote)",
     "asar": false,
+    "afterPack": "scripts/after-pack-adhoc-sign.js",
     "directories": {
       "output": "release",
       "app": "."

--- a/scripts/after-pack-adhoc-sign.js
+++ b/scripts/after-pack-adhoc-sign.js
@@ -1,0 +1,26 @@
+// electron-builder afterPack hook: deep ad-hoc sign the mac app.
+//
+// With `identity: null` electron-builder skips signing entirely, leaving the
+// Electron binary's linker signature over a MODIFIED bundle — an INVALID
+// seal. Quarantined downloads of such an app get macOS's "damaged, move to
+// trash" dialog, recoverable only via `xattr -cr` in a terminal. A valid
+// (deep) ad-hoc signature downgrades that to the standard "unidentified
+// developer" dialog, which users clear with right-click > Open — no
+// terminal. Real Developer ID signing + notarization supersedes this later.
+const { execFileSync } = require('child_process')
+const path = require('path')
+
+exports.default = async function afterPack(context) {
+  if (context.electronPlatformName !== 'darwin') return
+
+  const appName = `${context.packager.appInfo.productFilename}.app`
+  const appPath = path.join(context.appOutDir, appName)
+
+  execFileSync('codesign', ['--force', '--deep', '--sign', '-', appPath], {
+    stdio: 'inherit'
+  })
+  execFileSync('codesign', ['--verify', '--deep', '--strict', appPath], {
+    stdio: 'inherit'
+  })
+  console.log(`  • ad-hoc signed (deep)  app=${appPath}`)
+}


### PR DESCRIPTION
## mac: 初回起動の「ターミナル必須」を解消
これまで `identity: null` = 署名完全スキップのため、Electron バイナリの linker 署名が改変済み bundle を指す **invalid seal** となり、ダウンロードした dmg は「壊れているため開けません」→ `xattr -cr` がターミナルで必須だった。

afterPack フックで **deep ad-hoc 署名**（`codesign --force --deep -s -`）を実施。署名が有効になることで、Gatekeeper の判定が標準の「開発元を確認できません」に変わり、**右クリック → 開く だけで起動可能**（ターミナル不要）になる。

検証: `codesign --verify --deep --strict` PASS / invalid-seal メッセージ消滅 / 署名後アプリの実起動プローブ `{cover:false, content:2, sidenav:true}`

## Windows: 実起動スモークテスト CI
`win-smoke.yml`（workflow_dispatch）: windows-latest ランナーで**リリース済みの NSIS exe を実際にサイレントインストール → 実起動 → DOM プローブでメイン UI 到達を機械判定**。v0.16.2/0.16.3 で起きた「ビルドは通るが実機で splash 停止」を Windows 実機でも検出できるようにする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)